### PR TITLE
[Feat] 국가 목록 조회

### DIFF
--- a/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
+++ b/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         //실제 경로는 "/auth/kakao/login", "/auth/token/refresh
-                        .requestMatchers("/auth/**",
+                        .requestMatchers("/auth/**", "/countries",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",

--- a/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
+++ b/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         //실제 경로는 "/auth/kakao/login", "/auth/token/refresh
-                        .requestMatchers("/auth/**", "/countries",
+                        .requestMatchers("/auth/kakao/login", "/auth/token/refresh",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",

--- a/src/main/java/com/snapsplit/backend/domain/country/entity/Country.java
+++ b/src/main/java/com/snapsplit/backend/domain/country/entity/Country.java
@@ -1,0 +1,27 @@
+package com.snapsplit.backend.domain.country.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "country")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Country {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "country_id")
+    private Long id; // 국가 아이디
+
+    @Column(name = "country_name", length = 100, nullable = false)
+    private String countryName; // 국가 이름
+
+    @Column(length = 20)
+    private String currency; // 통화
+
+    @Column(name = "country_image", length = 255)
+    private String countryImage; // 국가 대표 이미지
+}

--- a/src/main/java/com/snapsplit/backend/domain/country/repository/CountryRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/country/repository/CountryRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.country.repository;
+
+import com.snapsplit.backend.domain.country.entity.Country;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CountryRepository extends JpaRepository<Country, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
@@ -1,0 +1,43 @@
+package com.snapsplit.backend.domain.trip.entity;
+
+import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "trip")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Trip {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_id")
+    private Long id; // 여행 아이디
+
+    @Column(name = "trip_name", length = 100, nullable = false)
+    private String tripName; // 여행 이름
+
+    @Column(nullable = false)
+    private LocalDate startDate; // 시작일
+
+    @Column(nullable = false)
+    private LocalDate endDate; // 종료일
+
+    @Column(name = "trip_image", length = 255)
+    private String tripImage; // 여행 대표사진
+
+    @Column(name = "trip_total_expense")
+    private BigDecimal tripTotalExpense; // 지출 총액
+
+    // 여행 - 여행국가 1 : n 관계
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TripCountry> tripCountries = new ArrayList<>();
+}

--- a/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.trip.repository;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/tripcountry/entity/TripCountry.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripcountry/entity/TripCountry.java
@@ -1,0 +1,28 @@
+package com.snapsplit.backend.domain.tripcountry.entity;
+
+import com.snapsplit.backend.domain.country.entity.Country;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "trip_country")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TripCountry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_country_id")
+    private Long id; // 여행국가 아이디
+
+    @ManyToOne
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip; // 여행 아이디
+
+    @ManyToOne
+    @JoinColumn(name = "country_id", nullable = false)
+    private Country country; // 국가 아이디
+}

--- a/src/main/java/com/snapsplit/backend/domain/tripcountry/repository/TripCountryRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripcountry/repository/TripCountryRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.tripcountry.repository;
+
+import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripCountryRepository extends JpaRepository<TripCountry, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/feature/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/controller/KakaoAuthController.java
@@ -1,8 +1,8 @@
-package com.snapsplit.backend.domain.auth.controller;
-import com.snapsplit.backend.domain.auth.dto.*;
-import com.snapsplit.backend.domain.auth.service.KakaoOAuthService;
-import com.snapsplit.backend.domain.auth.token.RefreshToken;
-import com.snapsplit.backend.domain.auth.token.RefreshTokenService;
+package com.snapsplit.backend.feature.auth.controller;
+import com.snapsplit.backend.feature.auth.dto.*;
+import com.snapsplit.backend.feature.auth.service.KakaoOAuthService;
+import com.snapsplit.backend.feature.auth.token.RefreshToken;
+import com.snapsplit.backend.feature.auth.token.RefreshTokenService;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.global.jwt.JwtUtil;
 import com.snapsplit.backend.global.response.ApiResponse;

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/KakaoTokenResponse.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/KakaoUserResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/KakaoUserResponse.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import lombok.Data;
 

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/LogoutRequest.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/RefreshRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/RefreshRequest.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import lombok.Data;
 

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/TokenResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/TokenResponse.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/snapsplit/backend/feature/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/service/KakaoOAuthService.java
@@ -1,7 +1,7 @@
-package com.snapsplit.backend.domain.auth.service;
+package com.snapsplit.backend.feature.auth.service;
 
-import com.snapsplit.backend.domain.auth.dto.KakaoTokenResponse;
-import com.snapsplit.backend.domain.auth.dto.KakaoUserResponse;
+import com.snapsplit.backend.feature.auth.dto.KakaoTokenResponse;
+import com.snapsplit.backend.feature.auth.dto.KakaoUserResponse;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Random;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshToken.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshToken.java
@@ -1,12 +1,10 @@
-package com.snapsplit.backend.domain.auth.token;
+package com.snapsplit.backend.feature.auth.token;
 
 import com.snapsplit.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Entity
 @Getter

--- a/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshTokenRepository.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshTokenRepository.java
@@ -1,9 +1,8 @@
-package com.snapsplit.backend.domain.auth.token;
+package com.snapsplit.backend.feature.auth.token;
 
 import com.snapsplit.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {

--- a/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshTokenService.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshTokenService.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.token;
+package com.snapsplit.backend.feature.auth.token;
 
 import com.snapsplit.backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
@@ -17,6 +17,7 @@ public class CountryListController {
 
     private final CountryListService countryListService;
 
+    // 전체 국가 목록 조회
     @GetMapping
     public ApiResponse<List<CountryListResponse>> getAllCountries() {
         List<CountryListResponse> result = countryListService.getAllCountries();

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
@@ -1,0 +1,25 @@
+package com.snapsplit.backend.feature.getCountryTrip.controller;
+
+import com.snapsplit.backend.feature.getCountryTrip.dto.CountryListResponse;
+import com.snapsplit.backend.feature.getCountryTrip.service.CountryListService;
+import com.snapsplit.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/countries")
+@RequiredArgsConstructor
+public class CountryListController {
+
+    private final CountryListService countryListService;
+
+    @GetMapping
+    public ApiResponse<List<CountryListResponse>> getAllCountries() {
+        List<CountryListResponse> result = countryListService.getAllCountries();
+        return ApiResponse.success("국가 리스트 조회 성공", result);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/dto/CountryListResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/dto/CountryListResponse.java
@@ -1,0 +1,15 @@
+package com.snapsplit.backend.feature.getCountryTrip.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CountryListResponse {
+    private Long countryId; // 국가 아이디
+    private String countryName; // 국가명
+}

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/service/CountryListService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/service/CountryListService.java
@@ -15,6 +15,7 @@ public class CountryListService {
 
     private final CountryRepository countryRepository;
 
+    // 전체 국가 목록 조회
     public List<CountryListResponse> getAllCountries() {
         List<Country> countries = countryRepository.findAll();
         return countries.stream()

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/service/CountryListService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/service/CountryListService.java
@@ -1,0 +1,27 @@
+package com.snapsplit.backend.feature.getCountryTrip.service;
+
+import com.snapsplit.backend.domain.country.entity.Country;
+import com.snapsplit.backend.domain.country.repository.CountryRepository;
+import com.snapsplit.backend.feature.getCountryTrip.dto.CountryListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CountryListService {
+
+    private final CountryRepository countryRepository;
+
+    public List<CountryListResponse> getAllCountries() {
+        List<Country> countries = countryRepository.findAll();
+        return countries.stream()
+                .map(country -> CountryListResponse.builder()
+                        .countryId(country.getId())
+                        .countryName(country.getCountryName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
@@ -10,6 +10,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -43,8 +45,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             if (token != null && jwtUtil.validateToken(token)) {
                 String kakaoId = jwtUtil.getKakaoIdFromToken(token);
-                request.setAttribute("kakaoId", kakaoId);
+
+                UsernamePasswordAuthenticationToken authenticationToken =
+                        new UsernamePasswordAuthenticationToken(kakaoId, null, null);
+
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             }
+
 
             filterChain.doFilter(request, response);
 

--- a/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.snapsplit.backend.global.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snapsplit.backend.global.response.ApiResponse;
+import com.snapsplit.backend.global.security.CustomUserPrincipal;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -44,11 +45,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             if (token != null && jwtUtil.validateToken(token)) {
+                // jwt에서 사용자 정보 식별 정보 추출
+                Long userId = jwtUtil.getUserIdFromToken(token);
                 String kakaoId = jwtUtil.getKakaoIdFromToken(token);
+                String nickname = jwtUtil.getNicknameFromToken(token);
 
+                // 추출한 정보로 커스텀 인증 객체 생성
+                CustomUserPrincipal principal = new CustomUserPrincipal(userId, kakaoId, nickname);
+
+                // SecurityContext에 인증 객체 설정
                 UsernamePasswordAuthenticationToken authenticationToken =
-                        new UsernamePasswordAuthenticationToken(kakaoId, null, null);
-
+                        new UsernamePasswordAuthenticationToken(principal, null, null);
                 SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             }
 

--- a/src/main/java/com/snapsplit/backend/global/jwt/JwtUtil.java
+++ b/src/main/java/com/snapsplit/backend/global/jwt/JwtUtil.java
@@ -35,26 +35,28 @@ public class JwtUtil {
         this.REFRESH_TOKEN_EXP = refreshExp;
     }
 
-    // access token 생성
     public String generateAccessToken(User user) {
-        return createToken(user.getKakaoId(), ACCESS_TOKEN_EXP, "access");
+        return createToken(user.getKakaoId(), ACCESS_TOKEN_EXP, "access", user.getId(), user.getName());
     }
 
-    // refresh token 생성
     public String generateRefreshToken(User user) {
-        return createToken(user.getKakaoId(), REFRESH_TOKEN_EXP, "refresh");
+        return createToken(user.getKakaoId(), REFRESH_TOKEN_EXP, "refresh", user.getId(), user.getName());
     }
+
 
     // jwt 생성
-    private String createToken(String kakaoId, long expireTime, String tokenType) {
+    private String createToken(String kakaoId, long expireTime, String tokenType, Long userId, String nickname) {
         return Jwts.builder()
                 .setSubject(kakaoId)
-                .claim("tokenType", tokenType)
+                .claim("id", userId) // 사용자 아이디
+                .claim("nickname", nickname) // 사용자 닉네임
+                .claim("tokenType", tokenType) // 토큰 타입
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expireTime))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
+
 
     // token에서 kakaoId 추출
     public String getKakaoIdFromToken(String token) {
@@ -66,6 +68,27 @@ public class JwtUtil {
                 .getBody()
                 .getSubject();
     }
+
+    // token에서 userId 추출
+    public Long getUserIdFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("id", Long.class);
+    }
+
+    // token에서 nickname 추출
+    public String getNicknameFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("nickname", String.class);
+    }
+
 
     // jwt 유효성 검사
     public boolean validateToken(String token) {

--- a/src/main/java/com/snapsplit/backend/global/security/CustomUserPrincipal.java
+++ b/src/main/java/com/snapsplit/backend/global/security/CustomUserPrincipal.java
@@ -1,0 +1,13 @@
+package com.snapsplit.backend.global.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomUserPrincipal {
+    // 커스텀 인증 객체
+    private Long id; // 사용자 아이디
+    private String kakaoId; // 카카오 아이디
+    private String nickname; // 닉네임
+}


### PR DESCRIPTION
### ✨ 개요
국가 목록 조회 기능 구현

### ✅ 세부 내용
- 여행 등록 시 선택할 국가 목록 조회 API 구현

### 🌏 관련 API
- GET /countries

### 📝 참고 사항
- 구현 중 인증 객체(SecurityContext) 등록 방식에서 문제를 파악 → 개선 작업 진행
  - 커스텀 인증 객체(CustomUserPrincipal) 도입
  - SecurityContext에 적용하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 국가, 여행, 여행-국가 연관 엔티티 및 관련 레포지토리 추가
  * 국가 리스트 조회 API 추가
  * JWT 토큰에 사용자 ID와 닉네임 정보 포함 및 추출 기능 추가
  * 사용자 인증 정보로 커스텀 유저 프린시펄 적용

* **버그 수정**
  * 인증되지 않은 접근 허용 경로를 일부 엔드포인트로 제한

* **리팩터**
  * 인증 관련 패키지 구조 변경 및 관련 클래스 이동

* **기타**
  * Swagger 및 API 문서 관련 경로는 기존과 동일하게 유지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->