### PR TITLE
[Feat] 신규 여행 등록하기

### DIFF
--- a/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
+++ b/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         //실제 경로는 "/auth/kakao/login", "/auth/token/refresh
-                        .requestMatchers("/auth/**",
+                        .requestMatchers("/auth/**", "/countries",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",

--- a/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
+++ b/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         //실제 경로는 "/auth/kakao/login", "/auth/token/refresh
-                        .requestMatchers("/auth/**", "/countries",
+                        .requestMatchers("/auth/kakao/login", "/auth/token/refresh",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",

--- a/src/main/java/com/snapsplit/backend/domain/country/entity/Country.java
+++ b/src/main/java/com/snapsplit/backend/domain/country/entity/Country.java
@@ -1,0 +1,27 @@
+package com.snapsplit.backend.domain.country.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "country")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Country {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "country_id")
+    private Long id; // 국가 아이디
+
+    @Column(name = "country_name", length = 100, nullable = false)
+    private String countryName; // 국가 이름
+
+    @Column(length = 20)
+    private String currency; // 통화
+
+    @Column(name = "country_image", length = 255)
+    private String countryImage; // 국가 대표 이미지
+}

--- a/src/main/java/com/snapsplit/backend/domain/country/repository/CountryRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/country/repository/CountryRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.country.repository;
+
+import com.snapsplit.backend.domain.country.entity.Country;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CountryRepository extends JpaRepository<Country, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/totalshared/entity/TotalShared.java
+++ b/src/main/java/com/snapsplit/backend/domain/totalshared/entity/TotalShared.java
@@ -1,0 +1,35 @@
+package com.snapsplit.backend.domain.totalshared.entity;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "total_shared")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TotalShared {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "total_shared_id")
+    private Long id; // 경비총액 아이디
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip; // 여행 아이디
+
+    @Column(name = "total_shared_amount", nullable = false)
+    private BigDecimal totalSharedAmount; // 총 경비
+
+    @Column(name = "total_shared_currency", nullable = false, length = 10)
+    private String totalSharedCurrency; // 통화
+
+    @Column(name = "latest_modified", nullable = false)
+    private LocalDate latestModified; // 마지막 수정일
+}

--- a/src/main/java/com/snapsplit/backend/domain/totalshared/repository/TotalSharedRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/totalshared/repository/TotalSharedRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.totalshared.repository;
+
+import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TotalSharedRepository extends JpaRepository<TotalShared, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
@@ -1,0 +1,43 @@
+package com.snapsplit.backend.domain.trip.entity;
+
+import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "trip")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Trip {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_id")
+    private Long id; // 여행 아이디
+
+    @Column(name = "trip_name", length = 100, nullable = false)
+    private String tripName; // 여행 이름
+
+    @Column(nullable = false)
+    private LocalDate startDate; // 시작일
+
+    @Column(nullable = false)
+    private LocalDate endDate; // 종료일
+
+    @Column(name = "trip_image", length = 255)
+    private String tripImage; // 여행 대표사진
+
+    @Column(name = "trip_total_expense")
+    private BigDecimal tripTotalExpense; // 지출 총액
+
+    // 여행 - 여행국가 1 : n 관계
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TripCountry> tripCountries = new ArrayList<>();
+}

--- a/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.trip.repository;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/tripcountry/entity/TripCountry.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripcountry/entity/TripCountry.java
@@ -1,0 +1,28 @@
+package com.snapsplit.backend.domain.tripcountry.entity;
+
+import com.snapsplit.backend.domain.country.entity.Country;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "trip_country")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TripCountry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_country_id")
+    private Long id; // 여행국가 아이디
+
+    @ManyToOne
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip; // 여행 아이디
+
+    @ManyToOne
+    @JoinColumn(name = "country_id", nullable = false)
+    private Country country; // 국가 아이디
+}

--- a/src/main/java/com/snapsplit/backend/domain/tripcountry/repository/TripCountryRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripcountry/repository/TripCountryRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.tripcountry.repository;
+
+import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripCountryRepository extends JpaRepository<TripCountry, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/tripmember/entity/MemberType.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/entity/MemberType.java
@@ -1,0 +1,6 @@
+package com.snapsplit.backend.domain.tripmember.entity;
+
+public enum MemberType {
+    USER,
+    SHARED_FUND
+}

--- a/src/main/java/com/snapsplit/backend/domain/tripmember/entity/TripMember.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/entity/TripMember.java
@@ -16,17 +16,17 @@ public class TripMember {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "trip_member_id")
-    private Long id; // 여행참가자 아이디
+    private Long id; // tripmember 아이디
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trip_id", nullable = false)
     private Trip trip; // 여행 아이디
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user; // 유저 아이디
+    @JoinColumn(name = "user_id", nullable = true)
+    private User user; // 유저 아이디 (공동경비는 null 가능)
 
     @Enumerated(EnumType.STRING)
     @Column(name = "member_type", nullable = false)
-    private MemberType memberType; // 멤버 타입 (user, shared_fund 등)
+    private MemberType memberType; // USER or SHARED_FUND
 }

--- a/src/main/java/com/snapsplit/backend/domain/tripmember/entity/TripMember.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/entity/TripMember.java
@@ -1,0 +1,32 @@
+package com.snapsplit.backend.domain.tripmember.entity;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "trip_member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TripMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_member_id")
+    private Long id; // 여행참가자 아이디
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip; // 여행 아이디
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 유저 아이디
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_type", nullable = false)
+    private MemberType memberType; // 멤버 타입 (user, shared_fund 등)
+}

--- a/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.tripmember.repository;
+
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/user/repository/UserRepository.java
@@ -6,5 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    // 카카오 아이디로 사용자 찾기
     Optional<User> findByKakaoId(String kakaoId);
+
+    // 유저 코드로 사용자 찾기
+    Optional<User> findByUserCode(String userCode);
 }

--- a/src/main/java/com/snapsplit/backend/feature/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/controller/KakaoAuthController.java
@@ -1,8 +1,8 @@
-package com.snapsplit.backend.domain.auth.controller;
-import com.snapsplit.backend.domain.auth.dto.*;
-import com.snapsplit.backend.domain.auth.service.KakaoOAuthService;
-import com.snapsplit.backend.domain.auth.token.RefreshToken;
-import com.snapsplit.backend.domain.auth.token.RefreshTokenService;
+package com.snapsplit.backend.feature.auth.controller;
+import com.snapsplit.backend.feature.auth.dto.*;
+import com.snapsplit.backend.feature.auth.service.KakaoOAuthService;
+import com.snapsplit.backend.feature.auth.token.RefreshToken;
+import com.snapsplit.backend.feature.auth.token.RefreshTokenService;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.global.jwt.JwtUtil;
 import com.snapsplit.backend.global.response.ApiResponse;

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/KakaoTokenResponse.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/KakaoUserResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/KakaoUserResponse.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import lombok.Data;
 

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/LogoutRequest.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/RefreshRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/RefreshRequest.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import lombok.Data;
 

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/TokenResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/TokenResponse.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.dto;
+package com.snapsplit.backend.feature.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/snapsplit/backend/feature/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/service/KakaoOAuthService.java
@@ -1,7 +1,7 @@
-package com.snapsplit.backend.domain.auth.service;
+package com.snapsplit.backend.feature.auth.service;
 
-import com.snapsplit.backend.domain.auth.dto.KakaoTokenResponse;
-import com.snapsplit.backend.domain.auth.dto.KakaoUserResponse;
+import com.snapsplit.backend.feature.auth.dto.KakaoTokenResponse;
+import com.snapsplit.backend.feature.auth.dto.KakaoUserResponse;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Random;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshToken.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshToken.java
@@ -1,12 +1,10 @@
-package com.snapsplit.backend.domain.auth.token;
+package com.snapsplit.backend.feature.auth.token;
 
 import com.snapsplit.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Entity
 @Getter

--- a/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshTokenRepository.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshTokenRepository.java
@@ -1,9 +1,8 @@
-package com.snapsplit.backend.domain.auth.token;
+package com.snapsplit.backend.feature.auth.token;
 
 import com.snapsplit.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {

--- a/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshTokenService.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/token/RefreshTokenService.java
@@ -1,4 +1,4 @@
-package com.snapsplit.backend.domain.auth.token;
+package com.snapsplit.backend.feature.auth.token;
 
 import com.snapsplit.backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/controller/CreateTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/controller/CreateTripController.java
@@ -1,0 +1,40 @@
+package com.snapsplit.backend.feature.createTrip.controller;
+
+import org.springframework.web.bind.annotation.RequestBody;
+import com.snapsplit.backend.feature.createTrip.dto.CreateTripRequest;
+import com.snapsplit.backend.feature.createTrip.dto.TripResponse;
+import com.snapsplit.backend.feature.createTrip.service.CreateTripService;
+import com.snapsplit.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/trips")
+@RequiredArgsConstructor
+public class CreateTripController {
+
+    private final CreateTripService createTripService;
+
+    // 신규 여행 등록하기
+    @PostMapping("/create")
+    public ResponseEntity<ApiResponse<List<TripResponse>>> createTrip(@RequestBody CreateTripRequest request) {
+
+        // 여행 생성 후 여행 아이디 리턴받기
+        Long tripId = createTripService.createTrip(request);
+        // 현재 시각 받아오기
+        String now = LocalDateTime.now().toString();
+
+        TripResponse response = new TripResponse(tripId, now);
+        List<TripResponse> data = List.of(response);
+
+        return ResponseEntity.ok(
+                ApiResponse.success("여행이 성공적으로 등록되었습니다.", data)
+        );
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/controller/TripMemberController.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/controller/TripMemberController.java
@@ -1,0 +1,38 @@
+package com.snapsplit.backend.feature.createTrip.controller;
+
+import com.snapsplit.backend.feature.auth.dto.KakaoUserResponse;
+import com.snapsplit.backend.feature.createTrip.dto.TripMemberResponse;
+import com.snapsplit.backend.feature.createTrip.service.TripMemberService;
+import com.snapsplit.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class TripMemberController {
+
+    private final TripMemberService tripMemberService;
+
+    // 유저 코드로 유저 검색
+    @GetMapping("/code/{userCode}")
+    public ResponseEntity<ApiResponse<TripMemberResponse>> getUserByUserCode(
+            @PathVariable String userCode,
+            @AuthenticationPrincipal(expression = "id") Long currentUserId
+    ) {
+        TripMemberResponse response = tripMemberService.findByUserCode(userCode, currentUserId);
+
+        // 검색 결과가 존재하지 않아 비어있을 경우
+        if (response == null) {
+            return ResponseEntity.ok(ApiResponse.success("검색된 사용자가 없습니다.", null));
+        }
+
+        // 검색 결과가 존재할 경우
+        return ResponseEntity.ok(ApiResponse.success("사용자 조회 성공", response));
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/dto/CountryDto.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/dto/CountryDto.java
@@ -1,0 +1,9 @@
+package com.snapsplit.backend.feature.createTrip.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CountryDto {
+    private Long countryId; // 국가 아이디
+    private String countryName; // 국가 이름
+}

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/dto/CreateTripRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/dto/CreateTripRequest.java
@@ -1,0 +1,15 @@
+package com.snapsplit.backend.feature.createTrip.dto;
+
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class CreateTripRequest {
+
+    private String tripName; // 여행 이름
+    private List<CountryDto> countries; // 여행 국가 리스트
+    private String startDate; // 여행 시작일
+    private String endDate; // 여행 종료일
+    private List<Long> tripMembersId; // 여행 멤버 리스트
+    private String tripImage; // 여행 대표 사진
+}

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/dto/TripMemberResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/dto/TripMemberResponse.java
@@ -1,0 +1,21 @@
+package com.snapsplit.backend.feature.createTrip.dto;
+
+import com.snapsplit.backend.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TripMemberResponse {
+    private Long id;
+    private String name;
+    private String profileImage;
+
+    public static TripMemberResponse from(User user) {
+        return new TripMemberResponse(
+                user.getId(),
+                user.getName(),
+                user.getProfileImage()
+        );
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/dto/TripResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/dto/TripResponse.java
@@ -1,0 +1,11 @@
+package com.snapsplit.backend.feature.createTrip.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TripResponse {
+    private Long tripId; // 여행 아이디
+    private String createdAt; // 생성일자
+}

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/service/CreateTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/service/CreateTripService.java
@@ -1,0 +1,98 @@
+package com.snapsplit.backend.feature.createTrip.service;
+
+import com.snapsplit.backend.domain.country.entity.Country;
+import com.snapsplit.backend.domain.country.repository.CountryRepository;
+import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
+import com.snapsplit.backend.domain.totalshared.repository.TotalSharedRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
+import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository;
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
+import com.snapsplit.backend.domain.user.repository.UserRepository;
+import com.snapsplit.backend.feature.createTrip.dto.CreateTripRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class CreateTripService {
+
+    private final TripRepository tripRepository;
+    private final CountryRepository countryRepository;
+    private final TripCountryRepository tripCountryRepository;
+    private final TripMemberRepository tripMemberRepository;
+    private final TotalSharedRepository totalSharedRepository;
+    private final UserRepository userRepository;
+
+    // 신규 여행 등록하기
+    @Transactional
+    public Long createTrip(CreateTripRequest request) {
+        Trip trip = Trip.builder()
+                .tripName(request.getTripName())
+                .startDate(LocalDate.parse(request.getStartDate()))
+                .endDate(LocalDate.parse(request.getEndDate()))
+                .tripImage(request.getTripImage())
+                .tripTotalExpense(BigDecimal.ZERO)
+                .build();
+        tripRepository.save(trip);
+
+        // 통화 코드 수집용 Set
+        Set<String> currencySet = new HashSet<>();
+
+        // TripCountry 생성
+        request.getCountries().forEach(countryDto -> {
+            Country country = countryRepository.findById(countryDto.getCountryId())
+                    .orElseThrow(() -> new RuntimeException("국가를 찾을 수 없습니다."));
+
+            TripCountry tripCountry = TripCountry.builder()
+                    .trip(trip)
+                    .country(country)
+                    .build();
+            tripCountryRepository.save(tripCountry);
+
+            currencySet.add(country.getCurrency());
+        });
+
+
+        // TripMember 생성 - 실제 여행 참여 유저
+        request.getTripMembersId().forEach(memberId -> {
+            TripMember tripMember = TripMember.builder()
+                    .trip(trip)
+                    .user(userRepository.findById(memberId)
+                            .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다.")))
+                    .memberType(com.snapsplit.backend.domain.tripmember.entity.MemberType.USER)
+                    .build();
+            tripMemberRepository.save(tripMember);
+        });
+
+        // TripMember 생성 - 공동경비
+        TripMember sharedFundMember = TripMember.builder()
+                .trip(trip)
+                .user(null)
+                .memberType(com.snapsplit.backend.domain.tripmember.entity.MemberType.SHARED_FUND)
+                .build();
+        tripMemberRepository.save(sharedFundMember);
+
+        // 선택된 여행 국가들에 대해
+        // 각 국가의 통화 기준으로 초기 TotalShared(경비 총액) 엔티티 생성
+        currencySet.forEach(currency -> {
+            TotalShared totalShared = TotalShared.builder()
+                    .trip(trip)
+                    .totalSharedAmount(BigDecimal.ZERO)
+                    .totalSharedCurrency(currency)
+                    .latestModified(LocalDate.now())
+                    .build();
+            totalSharedRepository.save(totalShared);
+        });
+
+        return trip.getId();
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/service/TripMemberService.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/service/TripMemberService.java
@@ -1,0 +1,29 @@
+package com.snapsplit.backend.feature.createTrip.service;
+
+import com.snapsplit.backend.domain.user.entity.User;
+import com.snapsplit.backend.domain.user.repository.UserRepository;
+import com.snapsplit.backend.feature.createTrip.dto.TripMemberResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TripMemberService {
+
+    private final UserRepository userRepository;
+
+    // 유저 코드로 유저 검색
+    public TripMemberResponse findByUserCode(String userCode, Long currentUserId) {
+        Optional<User> targetUserOptional = userRepository.findByUserCode(userCode);
+
+        // 유저 코드로 검색한 결과가 없거나 검색 결과가 사용자 본인이면 null 처리
+        if (targetUserOptional.isEmpty() || targetUserOptional.get().getId().equals(currentUserId)) {
+            return null;
+        }
+
+        User targetUser = targetUserOptional.get();
+        return TripMemberResponse.from(targetUser);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
@@ -17,6 +17,7 @@ public class CountryListController {
 
     private final CountryListService countryListService;
 
+    // 전체 국가 목록 조회
     @GetMapping
     public ApiResponse<List<CountryListResponse>> getAllCountries() {
         List<CountryListResponse> result = countryListService.getAllCountries();

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
@@ -1,0 +1,25 @@
+package com.snapsplit.backend.feature.getCountryTrip.controller;
+
+import com.snapsplit.backend.feature.getCountryTrip.dto.CountryListResponse;
+import com.snapsplit.backend.feature.getCountryTrip.service.CountryListService;
+import com.snapsplit.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/countries")
+@RequiredArgsConstructor
+public class CountryListController {
+
+    private final CountryListService countryListService;
+
+    @GetMapping
+    public ApiResponse<List<CountryListResponse>> getAllCountries() {
+        List<CountryListResponse> result = countryListService.getAllCountries();
+        return ApiResponse.success("국가 리스트 조회 성공", result);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/dto/CountryListResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/dto/CountryListResponse.java
@@ -1,0 +1,15 @@
+package com.snapsplit.backend.feature.getCountryTrip.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CountryListResponse {
+    private Long countryId; // 국가 아이디
+    private String countryName; // 국가명
+}

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/service/CountryListService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/service/CountryListService.java
@@ -15,6 +15,7 @@ public class CountryListService {
 
     private final CountryRepository countryRepository;
 
+    // 전체 국가 목록 조회
     public List<CountryListResponse> getAllCountries() {
         List<Country> countries = countryRepository.findAll();
         return countries.stream()

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/service/CountryListService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/service/CountryListService.java
@@ -1,0 +1,27 @@
+package com.snapsplit.backend.feature.getCountryTrip.service;
+
+import com.snapsplit.backend.domain.country.entity.Country;
+import com.snapsplit.backend.domain.country.repository.CountryRepository;
+import com.snapsplit.backend.feature.getCountryTrip.dto.CountryListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CountryListService {
+
+    private final CountryRepository countryRepository;
+
+    public List<CountryListResponse> getAllCountries() {
+        List<Country> countries = countryRepository.findAll();
+        return countries.stream()
+                .map(country -> CountryListResponse.builder()
+                        .countryId(country.getId())
+                        .countryName(country.getCountryName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
@@ -10,6 +10,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -43,8 +45,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             if (token != null && jwtUtil.validateToken(token)) {
                 String kakaoId = jwtUtil.getKakaoIdFromToken(token);
-                request.setAttribute("kakaoId", kakaoId);
+
+                UsernamePasswordAuthenticationToken authenticationToken =
+                        new UsernamePasswordAuthenticationToken(kakaoId, null, null);
+
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             }
+
 
             filterChain.doFilter(request, response);
 

--- a/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.snapsplit.backend.global.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snapsplit.backend.global.response.ApiResponse;
+import com.snapsplit.backend.global.security.CustomUserPrincipal;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -44,11 +45,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             if (token != null && jwtUtil.validateToken(token)) {
+                // jwt에서 사용자 정보 식별 정보 추출
+                Long userId = jwtUtil.getUserIdFromToken(token);
                 String kakaoId = jwtUtil.getKakaoIdFromToken(token);
+                String nickname = jwtUtil.getNicknameFromToken(token);
 
+                // 추출한 정보로 커스텀 인증 객체 생성
+                CustomUserPrincipal principal = new CustomUserPrincipal(userId, kakaoId, nickname);
+
+                // SecurityContext에 인증 객체 설정
                 UsernamePasswordAuthenticationToken authenticationToken =
-                        new UsernamePasswordAuthenticationToken(kakaoId, null, null);
-
+                        new UsernamePasswordAuthenticationToken(principal, null, null);
                 SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             }
 

--- a/src/main/java/com/snapsplit/backend/global/jwt/JwtUtil.java
+++ b/src/main/java/com/snapsplit/backend/global/jwt/JwtUtil.java
@@ -35,26 +35,28 @@ public class JwtUtil {
         this.REFRESH_TOKEN_EXP = refreshExp;
     }
 
-    // access token 생성
     public String generateAccessToken(User user) {
-        return createToken(user.getKakaoId(), ACCESS_TOKEN_EXP, "access");
+        return createToken(user.getKakaoId(), ACCESS_TOKEN_EXP, "access", user.getId(), user.getName());
     }
 
-    // refresh token 생성
     public String generateRefreshToken(User user) {
-        return createToken(user.getKakaoId(), REFRESH_TOKEN_EXP, "refresh");
+        return createToken(user.getKakaoId(), REFRESH_TOKEN_EXP, "refresh", user.getId(), user.getName());
     }
+
 
     // jwt 생성
-    private String createToken(String kakaoId, long expireTime, String tokenType) {
+    private String createToken(String kakaoId, long expireTime, String tokenType, Long userId, String nickname) {
         return Jwts.builder()
                 .setSubject(kakaoId)
-                .claim("tokenType", tokenType)
+                .claim("id", userId) // 사용자 아이디
+                .claim("nickname", nickname) // 사용자 닉네임
+                .claim("tokenType", tokenType) // 토큰 타입
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expireTime))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
+
 
     // token에서 kakaoId 추출
     public String getKakaoIdFromToken(String token) {
@@ -66,6 +68,27 @@ public class JwtUtil {
                 .getBody()
                 .getSubject();
     }
+
+    // token에서 userId 추출
+    public Long getUserIdFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("id", Long.class);
+    }
+
+    // token에서 nickname 추출
+    public String getNicknameFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("nickname", String.class);
+    }
+
 
     // jwt 유효성 검사
     public boolean validateToken(String token) {

--- a/src/main/java/com/snapsplit/backend/global/security/CustomUserPrincipal.java
+++ b/src/main/java/com/snapsplit/backend/global/security/CustomUserPrincipal.java
@@ -1,0 +1,13 @@
+package com.snapsplit.backend.global.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomUserPrincipal {
+    // 커스텀 인증 객체
+    private Long id; // 사용자 아이디
+    private String kakaoId; // 카카오 아이디
+    private String nickname; // 닉네임
+}


### PR DESCRIPTION
### ✨ 개요
국가 목록 조회, 유저 검색, 신규 여행 등록하기 기능을 한 번에 통합하여 업로드

### ✅ 세부 내용
🌏 국가 목록 조회 기능
- 여행 등록 시 선택할 국가 목록을 조회하는 API 구현

🔍 유저 검색 기능
- 사용자 코드를 기반으로 유저를 검색하는 API 구현
- 본인 코드는 결과에서 제외하도록 필터링 처리

🗺️ 신규 여행 등록하기
- 여행 정보(여행명, 기간, 이미지 등) 등록
- 여행 국가(TripCountry), 여행 멤버(TripMember), 공동경비 멤버 추가
- 선택된 국가 통화 기준으로 TotalShared 초기화
- 여행 등록 성공 시 tripId 및 생성 일자 반환

### 🔗 관련 API
- GET /countries
- GET /users/code/{userCode}
- POST /trips/create

### 📝 참고 사항
- 구현 중 인증 객체(SecurityContext) 등록 방식에서 문제를 파악 → 개선 작업 진행
    - 커스텀 인증 객체(CustomUserPrincipal) 도입
    - SecurityContext에 적용하도록 수정
- 프론트는 국가 ID만 전달하며, 통화 정보는 백엔드에서 DB 기준으로 자동 처리
- 공동경비 멤버는 실제 User를 참조하지 않고 member_type을 shared_fund로 지정하여 User가 아닌 TripMember로 구분하여 등록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여행 생성, 여행 멤버 검색, 국가 리스트 조회 등 여행 관련 API가 추가되었습니다.
  * 여행, 국가, 여행 멤버, 여행-국가 관계, 총 공유 금액 등 다양한 엔티티 및 관련 저장소가 추가되었습니다.
  * JWT 토큰에 사용자 ID와 닉네임 정보가 포함되어 인증 정보가 더욱 풍부해졌습니다.
  * 사용자 코드로 여행 멤버를 조회할 수 있는 기능이 추가되었습니다.

* **보안**
  * 인증이 필요 없는 엔드포인트가 일부로 제한되어 보안이 강화되었습니다.

* **리팩터**
  * 인증 관련 패키지 구조가 변경되어 코드 관리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->