### PR TITLE
[Feat] 마이페이지 정보 조회 및 수정하기

### DIFF
--- a/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
+++ b/src/main/java/com/snapsplit/backend/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.snapsplit.backend.config;
 
 import com.snapsplit.backend.global.jwt.JwtAuthenticationFilter;
 import com.snapsplit.backend.global.jwt.JwtUtil;
+import com.snapsplit.backend.global.security.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,7 @@ public class SecurityConfig {
     // JWT 생성, 검증 도구
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> redisTemplate;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -34,6 +36,9 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**").permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint) // ✅ 여기에 등록
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, redisTemplate), UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/snapsplit/backend/domain/user/entity/User.java
+++ b/src/main/java/com/snapsplit/backend/domain/user/entity/User.java
@@ -16,15 +16,18 @@ public class User {
     @Column(name = "user_id") // ← ERD 기준
     private Long id;
 
+    @Setter
     @Column(length = 50, nullable = false)
     private String name;
 
     @Column(name = "kakao_id", length = 100, unique = true, nullable = false)
     private String kakaoId;
 
+    @Setter
     @Column(name = "profile_image", length = 255)
     private String profileImage;
 
     @Column(name = "user_code", length = 50, unique = true, nullable = false)
     private String userCode;
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/myPage/controller/MyPageController.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/controller/MyPageController.java
@@ -1,0 +1,50 @@
+package com.snapsplit.backend.feature.myPage.controller;
+
+import com.snapsplit.backend.domain.user.repository.UserRepository;
+import com.snapsplit.backend.feature.myPage.dto.UserMyPageResponse;
+import com.snapsplit.backend.feature.myPage.service.MyPageService;
+import com.snapsplit.backend.domain.user.entity.User;
+import com.snapsplit.backend.global.response.ApiResponse;
+import com.snapsplit.backend.global.security.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/home/myPage")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+    private final UserRepository userRepository;
+
+    // GET /home/myPage
+    @GetMapping
+    public ResponseEntity<ApiResponse<UserMyPageResponse>> getMyPage(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        Long userId = principal.getId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        UserMyPageResponse response = myPageService.getMyPage(user);
+        return ResponseEntity.ok(ApiResponse.success("마이페이지 조회 성공", response));
+    }
+
+    // PUT /home/myPage
+    @PutMapping
+    public ResponseEntity<ApiResponse<Void>> updateProfile(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) MultipartFile profileImage
+    ) {
+        Long userId = principal.getId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        myPageService.updateProfile(user, name, profileImage);
+        return ResponseEntity.ok(ApiResponse.success("프로필 수정 완료", null));
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/myPage/controller/MyPageController.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/controller/MyPageController.java
@@ -1,7 +1,8 @@
 package com.snapsplit.backend.feature.myPage.controller;
 
 import com.snapsplit.backend.domain.user.repository.UserRepository;
-import com.snapsplit.backend.feature.myPage.dto.UserMyPageResponse;
+import com.snapsplit.backend.feature.myPage.dto.MyPageUpdateRequest;
+import com.snapsplit.backend.feature.myPage.dto.MyPageResponse;
 import com.snapsplit.backend.feature.myPage.service.MyPageService;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.global.response.ApiResponse;
@@ -11,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 @RestController
@@ -24,13 +24,13 @@ public class MyPageController {
 
     // GET /home/myPage
     @GetMapping
-    public ResponseEntity<ApiResponse<UserMyPageResponse>> getMyPage(
+    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
         Long userId = principal.getId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
-        UserMyPageResponse response = myPageService.getMyPage(user);
+        MyPageResponse response = myPageService.getMyPage(user);
         return ResponseEntity.ok(ApiResponse.success("마이페이지 조회 성공", response));
     }
 
@@ -38,13 +38,12 @@ public class MyPageController {
     @PutMapping
     public ResponseEntity<ApiResponse<Void>> updateProfile(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @RequestParam(required = false) String name,
-            @RequestParam(required = false) MultipartFile profileImage
+            @RequestBody MyPageUpdateRequest request
     ) {
         Long userId = principal.getId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
-        myPageService.updateProfile(user, name, profileImage);
+        myPageService.updateProfile(user, request.name(), request.profileImageUrl());
         return ResponseEntity.ok(ApiResponse.success("프로필 수정 완료", null));
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/myPage/dto/MyPageResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/dto/MyPageResponse.java
@@ -1,7 +1,7 @@
 package com.snapsplit.backend.feature.myPage.dto;
 
-public record UserMyPageResponse(
+public record MyPageResponse(
         String name,
-        String profileImage,
+        String profileImageUrl,
         String userCode
 ) {}

--- a/src/main/java/com/snapsplit/backend/feature/myPage/dto/MyPageUpdateRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/dto/MyPageUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.snapsplit.backend.feature.myPage.dto;
+
+public record MyPageUpdateRequest(
+        String name,
+        String profileImageUrl
+) {}

--- a/src/main/java/com/snapsplit/backend/feature/myPage/dto/UserMyPageResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/dto/UserMyPageResponse.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.feature.myPage.dto;
+
+public record UserMyPageResponse(
+        String name,
+        String profileImage,
+        String userCode
+) {}

--- a/src/main/java/com/snapsplit/backend/feature/myPage/service/MyPageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/service/MyPageService.java
@@ -1,0 +1,37 @@
+package com.snapsplit.backend.feature.myPage.service;
+
+import com.snapsplit.backend.domain.user.entity.User;
+import com.snapsplit.backend.feature.myPage.dto.UserMyPageResponse;
+import com.snapsplit.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+
+    public UserMyPageResponse getMyPage(User user) {
+        return new UserMyPageResponse(
+                user.getName(),
+                user.getProfileImage(),
+                user.getUserCode()
+        );
+    }
+
+    public void updateProfile(User user, String name, MultipartFile profileImage) {
+        if (name != null && !name.isBlank()) {
+            user.setName(name);
+        }
+
+        if (profileImage != null && !profileImage.isEmpty()) {
+            //실제 구현 시 S3Uploader 등으로 업로드
+            String dummyUrl = "https://example.com/dummy-profile.png";
+            user.setProfileImage(dummyUrl);
+        }
+
+        userRepository.save(user); // 변경 감지 또는 save
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/myPage/service/MyPageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/service/MyPageService.java
@@ -1,11 +1,10 @@
 package com.snapsplit.backend.feature.myPage.service;
 
 import com.snapsplit.backend.domain.user.entity.User;
-import com.snapsplit.backend.feature.myPage.dto.UserMyPageResponse;
+import com.snapsplit.backend.feature.myPage.dto.MyPageResponse;
 import com.snapsplit.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -13,23 +12,22 @@ public class MyPageService {
 
     private final UserRepository userRepository;
 
-    public UserMyPageResponse getMyPage(User user) {
-        return new UserMyPageResponse(
+    public MyPageResponse getMyPage(User user) {
+        return new MyPageResponse(
                 user.getName(),
                 user.getProfileImage(),
                 user.getUserCode()
         );
     }
 
-    public void updateProfile(User user, String name, MultipartFile profileImage) {
+    public void updateProfile(User user, String name, String profileImageUrl) {
+        System.out.println(">>> 이미지 변경 시도: " + profileImageUrl);
         if (name != null && !name.isBlank()) {
-            user.setName(name);
+            user.setName(name); //이름(닉네임) 변경
         }
 
-        if (profileImage != null && !profileImage.isEmpty()) {
-            //실제 구현 시 S3Uploader 등으로 업로드
-            String dummyUrl = "https://example.com/dummy-profile.png";
-            user.setProfileImage(dummyUrl);
+        if (profileImageUrl != null && !profileImageUrl.isEmpty()) {
+            user.setProfileImage(profileImageUrl); //프로필 이미지 변경
         }
 
         userRepository.save(user); // 변경 감지 또는 save

--- a/src/main/java/com/snapsplit/backend/feature/myPage/service/MyPageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/service/MyPageService.java
@@ -21,7 +21,6 @@ public class MyPageService {
     }
 
     public void updateProfile(User user, String name, String profileImageUrl) {
-        System.out.println(">>> 이미지 변경 시도: " + profileImageUrl);
         if (name != null && !name.isBlank()) {
             user.setName(name); //이름(닉네임) 변경
         }

--- a/src/main/java/com/snapsplit/backend/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/snapsplit/backend/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.snapsplit.backend.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snapsplit.backend.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        ApiResponse<Void> body = ApiResponse.fail(401, "유효하지 않은 Access Token입니다.");
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(mapper.writeValueAsString(body));
+    }
+}


### PR DESCRIPTION
### ✨ 개요
프로필 조회/수정 및 로그아웃이 가능한 마이페이지 구현

### ✅ 세부 내용
- 프로필 조회 (사용자 이름, 프로필 이미지, 유저코드 확인 가능)
- 프로필 수정 (사용자 이름, 프로필 이미지 수정 가능)
- 로그아웃 기능 w/블랙리스트 (로그아웃 API는 따로 구현 완료, 호출만 하면 됨)

### 🔐 관련 API
- GET /home/myPage
- PUT /home/myPage
- POST /auth/kakao/logout

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지 조회 및 프로필 수정 REST API가 추가되었습니다. (GET/PUT /home/myPage)
  * 사용자 프로필 정보(이름, 프로필 이미지, 유저 코드) 조회 및 수정이 가능합니다.

* **버그 수정**
  * JWT 인증 실패 시 사용자에게 명확한 401 에러 메시지가 JSON 형태로 반환됩니다.

* **기타**
  * 사용자 엔터티에서 이름과 프로필 이미지 변경이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->