### PR TITLE
[Feat] 기본 홈 - 다가오는 여행 조회

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
@@ -1,20 +1,7 @@
 package com.snapsplit.backend.domain.trip.repository;
 
 import com.snapsplit.backend.domain.trip.entity.Trip;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-import java.time.LocalDate;
-import java.util.List;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
-    @Query("""
-    select tm.trip
-    from TripMember tm
-    where tm.user.id = :userId
-      and tm.trip.startDate > :today
-    order by tm.trip.startDate asc
-""")
-    List<Trip> findUpcomingTripsByUserId(@Param("userId") Long userId, @Param("today") LocalDate today);
 }

--- a/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
@@ -1,7 +1,20 @@
 package com.snapsplit.backend.domain.trip.repository;
 
 import com.snapsplit.backend.domain.trip.entity.Trip;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
+    @Query("""
+    select tm.trip
+    from TripMember tm
+    where tm.user.id = :userId
+      and tm.trip.startDate > :today
+    order by tm.trip.startDate asc
+""")
+    List<Trip> findUpcomingTripsByUserId(@Param("userId") Long userId, @Param("today") LocalDate today);
 }

--- a/src/main/java/com/snapsplit/backend/domain/tripcountry/repository/TripCountryRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripcountry/repository/TripCountryRepository.java
@@ -3,5 +3,9 @@ package com.snapsplit.backend.domain.tripcountry.repository;
 import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TripCountryRepository extends JpaRepository<TripCountry, Long> {
+    //각 Trip에 해당하는 국가명 추출을 위해 TripCountry조회
+    List<TripCountry> findAllByTripId(Long tripId);
 }

--- a/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
@@ -1,7 +1,25 @@
 package com.snapsplit.backend.domain.tripmember.repository;
 
+import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
+
+    // userId에 해당하는 사용자가 참여 중인 여행 중,
+    // 오늘 이후 시작하는 여행들을 startDate 오름차순으로 조회
+    @Query("""
+    select tm.trip
+    from TripMember tm
+    where tm.user.id = :userId
+      and tm.trip.startDate > :today
+    order by tm.trip.startDate asc
+    """)
+    List<Trip> findUpcomingTripsByUserId(@Param("userId") Long userId, @Param("today") LocalDate today);
+
 }

--- a/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
@@ -2,9 +2,9 @@ package com.snapsplit.backend.domain.tripmember.repository;
 
 import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.tripmember.entity.TripMember;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/snapsplit/backend/feature/upcomingTrips/controller/UpcomingTripsController.java
+++ b/src/main/java/com/snapsplit/backend/feature/upcomingTrips/controller/UpcomingTripsController.java
@@ -1,0 +1,27 @@
+package com.snapsplit.backend.feature.upcomingTrips.controller;
+
+import com.snapsplit.backend.feature.upcomingTrips.dto.UpcomingTripResponse;
+import com.snapsplit.backend.feature.upcomingTrips.service.UpcomingTripsService;
+import com.snapsplit.backend.global.security.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trips")
+public class UpcomingTripsController {
+
+    private final UpcomingTripsService upcomingTripsService;
+
+    @GetMapping("/upcoming")
+    public ResponseEntity<List<UpcomingTripResponse>> getUpcomingTrips(
+            @AuthenticationPrincipal CustomUserPrincipal user
+    ) {
+        List<UpcomingTripResponse> trips = upcomingTripsService.getUpcomingTrips(user.getId());
+        return ResponseEntity.ok(trips);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/upcomingTrips/controller/UpcomingTripsController.java
+++ b/src/main/java/com/snapsplit/backend/feature/upcomingTrips/controller/UpcomingTripsController.java
@@ -3,7 +3,10 @@ package com.snapsplit.backend.feature.upcomingTrips.controller;
 import com.snapsplit.backend.feature.upcomingTrips.dto.UpcomingTripResponse;
 import com.snapsplit.backend.feature.upcomingTrips.service.UpcomingTripsService;
 import com.snapsplit.backend.global.security.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,10 +20,16 @@ public class UpcomingTripsController {
 
     private final UpcomingTripsService upcomingTripsService;
 
+    @Operation(summary = "다가오는 여행 목록 조회", description = "현재 날짜 기준으로 사용자의 다가오는 여행 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "성공적으로 조회됨")
+    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     @GetMapping("/upcoming")
     public ResponseEntity<List<UpcomingTripResponse>> getUpcomingTrips(
             @AuthenticationPrincipal CustomUserPrincipal user
     ) {
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         List<UpcomingTripResponse> trips = upcomingTripsService.getUpcomingTrips(user.getId());
         return ResponseEntity.ok(trips);
     }

--- a/src/main/java/com/snapsplit/backend/feature/upcomingTrips/dto/UpcomingTripResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/upcomingTrips/dto/UpcomingTripResponse.java
@@ -15,17 +15,13 @@ public class UpcomingTripResponse {
     private String tripName;
     private LocalDate startDate;
     private LocalDate endDate;
-    private String tripImage;
-    private BigDecimal tripTotalExpense;
 
     public static UpcomingTripResponse from(Trip trip) {
         return new UpcomingTripResponse(
                 trip.getId(),
                 trip.getTripName(),
                 trip.getStartDate(),
-                trip.getEndDate(),
-                trip.getTripImage(),
-                trip.getTripTotalExpense()
+                trip.getEndDate()
         );
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/upcomingTrips/dto/UpcomingTripResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/upcomingTrips/dto/UpcomingTripResponse.java
@@ -1,0 +1,31 @@
+package com.snapsplit.backend.feature.upcomingTrips.dto;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class UpcomingTripResponse {
+
+    private Long tripId;
+    private String tripName;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String tripImage;
+    private BigDecimal tripTotalExpense;
+
+    public static UpcomingTripResponse from(Trip trip) {
+        return new UpcomingTripResponse(
+                trip.getId(),
+                trip.getTripName(),
+                trip.getStartDate(),
+                trip.getEndDate(),
+                trip.getTripImage(),
+                trip.getTripTotalExpense()
+        );
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/upcomingTrips/dto/UpcomingTripResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/upcomingTrips/dto/UpcomingTripResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -15,13 +16,15 @@ public class UpcomingTripResponse {
     private String tripName;
     private LocalDate startDate;
     private LocalDate endDate;
+    private List<String> countryNames;
 
-    public static UpcomingTripResponse from(Trip trip) {
+    public static UpcomingTripResponse from(Trip trip, List<String> countryNames) {
         return new UpcomingTripResponse(
                 trip.getId(),
                 trip.getTripName(),
                 trip.getStartDate(),
-                trip.getEndDate()
+                trip.getEndDate(),
+                countryNames
         );
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/upcomingTrips/service/UpcomingTripsService.java
+++ b/src/main/java/com/snapsplit/backend/feature/upcomingTrips/service/UpcomingTripsService.java
@@ -1,0 +1,26 @@
+package com.snapsplit.backend.feature.upcomingTrips.service;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.feature.upcomingTrips.dto.UpcomingTripResponse;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UpcomingTripsService {
+
+    private final TripRepository tripRepository;
+
+    public List<UpcomingTripResponse> getUpcomingTrips(Long userId) {
+        LocalDate today = LocalDate.now();
+        List<Trip> trips = tripRepository.findUpcomingTripsByUserId(userId, today);
+        return trips.stream()
+                .map(UpcomingTripResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/upcomingTrips/service/UpcomingTripsService.java
+++ b/src/main/java/com/snapsplit/backend/feature/upcomingTrips/service/UpcomingTripsService.java
@@ -1,6 +1,10 @@
 package com.snapsplit.backend.feature.upcomingTrips.service;
 
+import com.snapsplit.backend.domain.country.entity.Country;
+import com.snapsplit.backend.domain.country.repository.CountryRepository;
 import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.upcomingTrips.dto.UpcomingTripResponse;
 import com.snapsplit.backend.domain.trip.repository.TripRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,13 +18,23 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class UpcomingTripsService {
 
-    private final TripRepository tripRepository;
+    private final TripMemberRepository tripMemberRepository;
+    private final TripCountryRepository tripCountryRepository;
 
     public List<UpcomingTripResponse> getUpcomingTrips(Long userId) {
         LocalDate today = LocalDate.now();
-        List<Trip> trips = tripRepository.findUpcomingTripsByUserId(userId, today);
+        List<Trip> trips = tripMemberRepository.findUpcomingTripsByUserId(userId, today);
+
         return trips.stream()
-                .map(UpcomingTripResponse::from)
+                .map(trip -> {
+                    // Trip → TripCountry → Country 관계를 통해 국가 이름 추출
+                    // 각 Trip의 국가 이름 목록은 TripCountry → Country → countryName으로 가져옴
+                    List<String> countryNames = tripCountryRepository.findAllByTripId(trip.getId()).stream()
+                            .map(tc -> tc.getCountry().getCountryName())
+                            .collect(Collectors.toList());
+
+                    return UpcomingTripResponse.from(trip, countryNames);
+                })
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snapsplit/backend/global/jwt/JwtAuthenticationFilter.java
@@ -77,10 +77,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
     }
 
-    //토큰 인증 없이 접근 가능한 경로는 로그인과 토큰재발급뿐
+    //토큰 인증 없이 접근 가능한 경로는 로그인과 토큰 재발급뿐
     private boolean isWhitelisted(String path) {
         return path.equals("/auth/kakao/login")
-                || path.equals("/auth/token/refresh");
+                || path.equals("/auth/token/refresh")
+                || path.startsWith("/swagger-ui")
+                || path.startsWith("/v3/api-docs");
     }
 
     //에러 응답 공통 처리 함수


### PR DESCRIPTION
### ✨ 개요
기본 홈에서 보여지는 다가오는 여행 목록 조회

### ✅ 세부 내용
- 기본 홈 상단에 사용자의 다가오는 여행 조회
- 다가오는 여행 전체 목록을 response로 응답하며 여행 이름, 여행 시작일/종료일, 여행 국가 내용 포함
- 여행 국가명 불러오는 흐름
  - TripMemberRepository에서 로그인 유저의 Trip 리스트 조회
  - 각 Trip에 대해 TripCountryRepository.findAllByTripId(tripId) 실행
  - 각 TripCountry 객체에서 getCountry() → getCountryName() 호출

### 🔐 관련 API
- GET /trips/upcoming

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 다가오는 여행 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 각 여행에는 여행 ID, 이름, 시작일, 종료일, 연관된 국가 목록이 포함됩니다.

* **버그 수정**
  * Swagger UI 및 API 문서 경로에 대한 인증 없이 접근이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->