### PR TITLE
[Feat] 기본 홈 - 지난 여행 목록 조회

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
@@ -2,6 +2,8 @@ package com.snapsplit.backend.domain.tripmember.repository;
 
 import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,7 +13,7 @@ import java.util.List;
 
 public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
 
-    // userId에 해당하는 사용자가 참여 중인 여행 중,
+    // userId에 해당하는 사용자가 참여 중인 Trip 중에서,
     // 오늘 이후 시작하는 여행들을 startDate 오름차순으로 조회
     @Query("""
     select tm.trip
@@ -21,5 +23,16 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
     order by tm.trip.startDate asc
     """)
     List<Trip> findUpcomingTripsByUserId(@Param("userId") Long userId, @Param("today") LocalDate today);
+
+    // userId에 해당하는 사용자가 참여한 Trip 중에서,
+    // endDate가 오늘보다 이전인 Trip들을 최신 순으로 limit만큼 가져오는 쿼리
+    @Query("""
+    select tm.trip
+    from TripMember tm
+    where tm.user.id = :userId
+      and tm.trip.endDate < :today
+    order by tm.trip.endDate desc
+""")
+    List<Trip> findPastTripsByUserId(@Param("userId") Long userId, @Param("today") LocalDate today, Pageable pageable);
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/controller/PastTripsController.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/controller/PastTripsController.java
@@ -3,6 +3,9 @@ package com.snapsplit.backend.feature.pastTrips.controller;
 import com.snapsplit.backend.feature.pastTrips.dto.PastTripResponse;
 import com.snapsplit.backend.feature.pastTrips.service.PastTripsService;
 import com.snapsplit.backend.global.security.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +20,11 @@ public class PastTripsController {
 
     private final PastTripsService pastTripsService;
 
+    @Operation(summary = "과거 여행 목록 조회", description = "사용자가 참여한 과거 여행 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @GetMapping("/past")
     public ResponseEntity<List<PastTripResponse>> getPastTrips(
             @AuthenticationPrincipal CustomUserPrincipal user,

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/controller/PastTripsController.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/controller/PastTripsController.java
@@ -1,0 +1,28 @@
+package com.snapsplit.backend.feature.pastTrips.controller;
+
+import com.snapsplit.backend.feature.pastTrips.dto.PastTripResponse;
+import com.snapsplit.backend.feature.pastTrips.service.PastTripsService;
+import com.snapsplit.backend.global.security.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trips")
+public class PastTripsController {
+
+    private final PastTripsService pastTripsService;
+
+    @GetMapping("/past")
+    public ResponseEntity<List<PastTripResponse>> getPastTrips(
+            @AuthenticationPrincipal CustomUserPrincipal user,
+            @RequestParam(required = false) Integer limit
+    ) {
+        List<PastTripResponse> trips = pastTripsService.getPastTrips(user.getId(), limit);
+        return ResponseEntity.ok(trips);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripResponse.java
@@ -1,0 +1,31 @@
+package com.snapsplit.backend.feature.pastTrips.dto;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PastTripResponse {
+
+    private Long tripId;
+    private String tripName;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String tripImage;
+    private List<String> countryNames;
+
+    public static PastTripResponse from(Trip trip, List<String> countryNames) {
+        return new PastTripResponse(
+                trip.getId(),
+                trip.getTripName(),
+                trip.getStartDate(),
+                trip.getEndDate(),
+                trip.getTripImage(),
+                countryNames
+        );
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/service/PastTripsService.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/service/PastTripsService.java
@@ -1,0 +1,43 @@
+package com.snapsplit.backend.feature.pastTrips.service;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
+import com.snapsplit.backend.feature.pastTrips.dto.PastTripResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PastTripsService {
+
+    private final TripMemberRepository tripMemberRepository;
+    private final TripCountryRepository tripCountryRepository;
+
+    public List<PastTripResponse> getPastTrips(Long userId, Integer limit) {
+        LocalDate today = LocalDate.now();
+
+        // limit이 지정되면 앞에서부터 limit개만 조회, 아니면 전체 조회
+        Pageable pageable = (limit != null) ? PageRequest.of(0, limit) : Pageable.unpaged();
+
+        // TripMember를 통해 userId가 참여한 Trip 중, 지난 여행(endDate < today)만 조회함
+        List<Trip> trips = tripMemberRepository.findPastTripsByUserId(userId, today, pageable);
+
+        return trips.stream()
+                .map(trip -> {
+                    // Trip → TripCountry → Country 연관관계를 따라 국가 이름 목록 추출
+                    List<String> countryNames = tripCountryRepository.findAllByTripId(trip.getId()).stream()
+                            .map(tc -> tc.getCountry().getCountryName())
+                            .collect(Collectors.toList());
+
+                    return PastTripResponse.from(trip, countryNames);
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### ✨ 개요
기본 홈 화면에서 지난 여행 목록을 조회하는 API(/trips/past)를 구현

### ✅ 세부 내용
- TripMemberRepository 기준으로 사용자 참여 여행만 필터링
- endDate < 오늘 조건으로 지난 여행만 조회
- limit 파라미터가 있으면 해당 개수만, 없으면 전체 조회 가능
- 응답 필드:
  - tripId, tripName, startDate, endDate
  - tripImage: 여행 대표사진
  - countryNames: Trip → TripCountry → Country 경로를 따라 추출한 국가 이름 목록

### 🔐 관련 API
- GET /trips/past
  - limit={n}: 최근 n개의 지난 여행 조회
  - 파라미터 생략 시 전체 지난 여행 조회

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 참여했던 지난 여행 목록을 조회할 수 있는 API가 추가되었습니다.  
  * 지난 여행의 기본 정보(여행명, 기간, 이미지, 방문 국가 등)를 확인할 수 있습니다.
  * 조회 시 결과 개수를 제한하는 옵션이 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->