### PR TITLE
[Feat] 신규 여행 등록 시 참여 코드 생성 로직 추가

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/shared/entity/PaymentMethod.java
+++ b/src/main/java/com/snapsplit/backend/domain/shared/entity/PaymentMethod.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.shared.entity;
+
+// 지불 방식
+public enum PaymentMethod {
+    cash, // 현금
+    credit_card // 신용카드
+}

--- a/src/main/java/com/snapsplit/backend/domain/shared/entity/Shared.java
+++ b/src/main/java/com/snapsplit/backend/domain/shared/entity/Shared.java
@@ -1,0 +1,40 @@
+package com.snapsplit.backend.domain.shared.entity;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "shared")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Shared {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shared_id")
+    private Long id; // 경비 아이디
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip; // 여행 아이디
+
+    @Column(name = "shared_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal amount; // 경비 입금액
+
+    @Column(name = "shared_currency", length = 10, nullable = false)
+    private String currency; // 경비 입금 통화
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDate createdAt; // 경비 입금일자
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_method", nullable = false)
+    private PaymentMethod paymentMethod; // 경비 입금 방식
+
+}

--- a/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
@@ -1,6 +1,9 @@
 package com.snapsplit.backend.domain.trip.entity;
 
+import com.snapsplit.backend.domain.shared.entity.Shared;
+import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
 import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -37,7 +40,26 @@ public class Trip {
     @Column(name = "trip_total_expense")
     private BigDecimal tripTotalExpense; // 지출 총액
 
+    @Column(name = "trip_code", length = 20, nullable = false, unique = true)
+    private String tripCode; // 여행 참여 코드
+
     // 여행 - 여행국가 1 : n 관계
+    // 여행이 삭제되면 TripCountry도 삭제되도록
     @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TripCountry> tripCountries = new ArrayList<>();
+
+    // 여행 - 여행 멤버 1 : n 관계
+    // 여행이 삭제되면 TripMember도 삭제되도록
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TripMember> tripMembers = new ArrayList<>();
+
+    // 여행 - 경비 총액 1 : n 관계
+    // 여행이 삭제되면 TotalShared도 삭제되도록
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TotalShared> totalSharedList = new ArrayList<>();
+
+    // 여행 - 경비 1 : n 관계
+    // 여행이 삭제되면 Shared도 삭제되도록
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Shared> sharedList = new ArrayList<>();
 }

--- a/src/main/java/com/snapsplit/backend/feature/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/controller/KakaoAuthController.java
@@ -8,6 +8,7 @@ import com.snapsplit.backend.global.jwt.JwtUtil;
 import com.snapsplit.backend.global.response.ApiResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -28,6 +29,10 @@ public class KakaoAuthController {
     private final RefreshTokenService refreshTokenService;
     private final RedisTemplate<String, String> redisTemplate;
 
+    @Operation(summary = "카카오 로그인",
+            description = "전달받은 인가 코드로 카카오에서 사용자 정보를 받고, " +
+                    "미가입된 회원일 시 회원가입 후 로그인하고 " +
+                    "가입된 회원일 시 바로 로그인합니다.")
     @PostMapping("/kakao/login")
     public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(@RequestParam String code) {
         // 인가 코드로 카카오 access token 받기
@@ -53,6 +58,7 @@ public class KakaoAuthController {
         );
     }
 
+    @Operation(summary = "로그아웃")
     @PostMapping("/kakao/logout")
     public ResponseEntity<ApiResponse<Void>> logout(@RequestBody LogoutRequest request,
                                                     HttpServletRequest httpRequest) {
@@ -88,6 +94,7 @@ public class KakaoAuthController {
         return ResponseEntity.ok(ApiResponse.success("로그아웃 완료", null));
     }
 
+    @Operation(summary = "access 토큰 재발급", description = "리프레시 토큰을 기반으로 액세스 토큰을 재발급합니다.")
     @PostMapping("/token/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> refreshAccessToken(@RequestBody RefreshRequest request) {
         // 클라이언트가 보낸 JSON에서 refreshToken 값 추출

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/controller/CreateTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/controller/CreateTripController.java
@@ -1,5 +1,6 @@
 package com.snapsplit.backend.feature.createTrip.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.RequestBody;
 import com.snapsplit.backend.feature.createTrip.dto.CreateTripRequest;
 import com.snapsplit.backend.feature.createTrip.dto.TripResponse;
@@ -22,6 +23,7 @@ public class CreateTripController {
     private final CreateTripService createTripService;
 
     // 신규 여행 등록하기
+    @Operation(summary = "신규 여행 등록하기", description = "새로운 여행을 등록합니다.")
     @PostMapping("/create")
     public ResponseEntity<ApiResponse<List<TripResponse>>> createTrip(@RequestBody CreateTripRequest request) {
         // 여행 생성 후 여행 아이디 리턴받기

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/controller/TripMemberController.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/controller/TripMemberController.java
@@ -4,6 +4,7 @@ import com.snapsplit.backend.feature.auth.dto.KakaoUserResponse;
 import com.snapsplit.backend.feature.createTrip.dto.TripMemberResponse;
 import com.snapsplit.backend.feature.createTrip.service.TripMemberService;
 import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,6 +21,7 @@ public class TripMemberController {
     private final TripMemberService tripMemberService;
 
     // 유저 코드로 유저 검색
+    @Operation(summary = "사용자 검색", description = "유저 코드로 여행에 초대할 사용자를 검색합니다.")
     @GetMapping("/code/{userCode}")
     public ResponseEntity<ApiResponse<TripMemberResponse>> getUserByUserCode(
             @PathVariable String userCode,

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/service/CreateTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/service/CreateTripService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.HashSet;
+import java.util.Random;
 import java.util.Set;
 
 @Service
@@ -35,12 +36,18 @@ public class CreateTripService {
     // 신규 여행 등록하기
     @Transactional
     public Long createTrip(CreateTripRequest request) {
+
+        // 8자리 랜덤 코드 생성
+        String tripCode = generateTripCode();
+
+        // Trip 생성
         Trip trip = Trip.builder()
                 .tripName(request.getTripName())
                 .startDate(LocalDate.parse(request.getStartDate()))
                 .endDate(LocalDate.parse(request.getEndDate()))
                 .tripImage(request.getTripImage())
                 .tripTotalExpense(BigDecimal.ZERO)
+                .tripCode(tripCode)
                 .build();
         tripRepository.save(trip);
 
@@ -94,5 +101,14 @@ public class CreateTripService {
         });
 
         return trip.getId();
+    }
+
+    // 8자리 랜덤 코드 생성 함수
+    private String generateTripCode() {
+        return new Random().ints(48, 122 + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(8)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCountryTrip/controller/CountryListController.java
@@ -3,6 +3,7 @@ package com.snapsplit.backend.feature.getCountryTrip.controller;
 import com.snapsplit.backend.feature.getCountryTrip.dto.CountryListResponse;
 import com.snapsplit.backend.feature.getCountryTrip.service.CountryListService;
 import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +19,7 @@ public class CountryListController {
     private final CountryListService countryListService;
 
     // 전체 국가 목록 조회
+    @Operation(summary = "전체 국가 목록 조회", description = "여행에 등록 가능한 전체 국가 목록을 조회합니다.")
     @GetMapping
     public ApiResponse<List<CountryListResponse>> getAllCountries() {
         List<CountryListResponse> result = countryListService.getAllCountries();

--- a/src/main/java/com/snapsplit/backend/feature/myPage/controller/MyPageController.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/controller/MyPageController.java
@@ -7,6 +7,7 @@ import com.snapsplit.backend.feature.myPage.service.MyPageService;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.global.response.ApiResponse;
 import com.snapsplit.backend.global.security.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,8 @@ public class MyPageController {
     private final UserRepository userRepository;
 
     // GET /home/myPage
+    // 마이페이지 조회
+    @Operation(summary = "마이페이지 조회", description = "마이페이지 정보를 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(
             @AuthenticationPrincipal CustomUserPrincipal principal
@@ -35,6 +38,8 @@ public class MyPageController {
     }
 
     // PUT /home/myPage
+    // 마이페이지 수정
+    @Operation(summary = "마이페이지 수정", description = "기존 마이페이지 정보를 수정합니다.")
     @PutMapping
     public ResponseEntity<ApiResponse<Void>> updateProfile(
             @AuthenticationPrincipal CustomUserPrincipal principal,


### PR DESCRIPTION
### ✨ 개요
- 신규 여행 등록 시, 여행 참여 코드 자동 생성 로직 추가

### ✅ 변경 내용
- 8자리 영문+숫자 조합의 참여 코드 생성 (UUID 기반 랜덤)

### 🔐 관련 API
- POST /trips/create

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여행에 참여할 수 있는 고유 코드(tripCode) 생성 및 할당 기능이 추가되었습니다.
  * 여행별 정산 내역(Shared) 및 결제수단(PaymentMethod) 관리 기능이 도입되었습니다.

* **문서화**
  * 카카오 인증, 여행 생성, 여행 멤버 검색, 국가 목록 조회, 마이페이지 API에 대한 Swagger 문서가 추가되어 API 사용 방법이 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->