### PR TITLE
[Feat] 기본 홈 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
@@ -34,5 +34,18 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
     order by tm.trip.endDate desc
 """)
     List<Trip> findPastTripsByUserId(@Param("userId") Long userId, @Param("today") LocalDate today, Pageable pageable);
+
+    // userId가 해당하는 사용자가 참여한 Trip 중에서,
+    // startDate가 오늘보다 이전이고, endDate가 오늘보다 이후인 Trip 가져오기
+    @Query("""
+    select tm.trip
+    from TripMember tm
+    where tm.user.id = :userId
+      and tm.trip.startDate <= :today
+      and tm.trip.endDate >= :today
+    order by tm.trip.startDate asc
+""")
+    List<Trip> findOngoingTripsByUserId(@Param("userId") Long userId, @Param("today") LocalDate today);
+
     boolean existsByTripAndUser(Trip trip, User user); // 이미 여행에 참여한 사용자인지 확인
 }

--- a/src/main/java/com/snapsplit/backend/feature/home/controller/HomeController.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/controller/HomeController.java
@@ -18,7 +18,7 @@ public class HomeController {
 
     private final HomeService homeService;
 
-    @Operation(summary = "기본 홈 조회", description = "로그인된 사용자 정보를 기반으로 기본 홈에 필요한 정보를 불러옵니다.")
+    @Operation(summary = "기본 홈 정보 조회", description = "로그인된 사용자 정보를 기반으로 기본 홈에 필요한 정보를 불러옵니다.")
     @GetMapping
     public ApiResponse<HomeResponse> getHome(@AuthenticationPrincipal CustomUserPrincipal user) {
         HomeResponse response = homeService.getHome(user.getId());

--- a/src/main/java/com/snapsplit/backend/feature/home/controller/HomeController.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/controller/HomeController.java
@@ -1,15 +1,15 @@
 package com.snapsplit.backend.feature.home.controller;
 
-import com.snapsplit.backend.feature.home.dto.HomeRequest;
 import com.snapsplit.backend.feature.home.dto.HomeResponse;
 import com.snapsplit.backend.feature.home.service.HomeService;
 import com.snapsplit.backend.global.response.ApiResponse;
+import com.snapsplit.backend.global.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 @RestController
 @RequestMapping("/home")
@@ -18,10 +18,10 @@ public class HomeController {
 
     private final HomeService homeService;
 
-    @Operation(summary = "기본 홈 조회", description = "사용자 ID를 기반으로 기본 홈에 필요한 정보를 불러옵니다.")
-    @PostMapping
-    public ApiResponse<HomeResponse> getHome(@RequestBody HomeRequest request) {
-        HomeResponse response = homeService.getHome(request.getUserId());
+    @Operation(summary = "기본 홈 조회", description = "로그인된 사용자 정보를 기반으로 기본 홈에 필요한 정보를 불러옵니다.")
+    @GetMapping
+    public ApiResponse<HomeResponse> getHome(@AuthenticationPrincipal CustomUserPrincipal user) {
+        HomeResponse response = homeService.getHome(user.getId());
         return ApiResponse.success("메인 홈 불러오기 성공", response);
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/home/controller/HomeController.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/controller/HomeController.java
@@ -1,0 +1,27 @@
+package com.snapsplit.backend.feature.home.controller;
+
+import com.snapsplit.backend.feature.home.dto.HomeRequest;
+import com.snapsplit.backend.feature.home.dto.HomeResponse;
+import com.snapsplit.backend.feature.home.service.HomeService;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/home")
+@RequiredArgsConstructor
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @Operation(summary = "기본 홈 조회", description = "사용자 ID를 기반으로 기본 홈에 필요한 정보를 불러옵니다.")
+    @PostMapping
+    public ApiResponse<HomeResponse> getHome(@RequestBody HomeRequest request) {
+        HomeResponse response = homeService.getHome(request.getUserId());
+        return ApiResponse.success("메인 홈 불러오기 성공", response);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/home/dto/HomeRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/dto/HomeRequest.java
@@ -1,8 +1,0 @@
-package com.snapsplit.backend.feature.home.dto;
-
-import lombok.Data;
-
-@Data
-public class HomeRequest {
-    private Long userId;
-}

--- a/src/main/java/com/snapsplit/backend/feature/home/dto/HomeRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/dto/HomeRequest.java
@@ -1,0 +1,8 @@
+package com.snapsplit.backend.feature.home.dto;
+
+import lombok.Data;
+
+@Data
+public class HomeRequest {
+    private Long userId;
+}

--- a/src/main/java/com/snapsplit/backend/feature/home/dto/HomeResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/dto/HomeResponse.java
@@ -1,0 +1,17 @@
+package com.snapsplit.backend.feature.home.dto;
+
+import com.snapsplit.backend.feature.pastTrips.dto.PastTripResponse;
+import com.snapsplit.backend.feature.upcomingTrips.dto.UpcomingTripResponse;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class HomeResponse {
+
+    private List<UpcomingTripResponse> upcomingTrips;
+    private List<PastTripResponse> pastTrips;
+
+}

--- a/src/main/java/com/snapsplit/backend/feature/home/dto/HomeResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/dto/HomeResponse.java
@@ -1,5 +1,6 @@
 package com.snapsplit.backend.feature.home.dto;
 
+import com.snapsplit.backend.feature.ongoingTrips.dto.OngoingTripResponse;
 import com.snapsplit.backend.feature.pastTrips.dto.PastTripResponse;
 import com.snapsplit.backend.feature.upcomingTrips.dto.UpcomingTripResponse;
 import lombok.Builder;
@@ -11,7 +12,8 @@ import java.util.List;
 @Builder
 public class HomeResponse {
 
-    private List<UpcomingTripResponse> upcomingTrips;
-    private List<PastTripResponse> pastTrips;
+    private List<UpcomingTripResponse> upcomingTrips; // 다가오는 여행
+    private List<OngoingTripResponse> ongoingTrips; // 진행중인 여행
+    private List<PastTripResponse> pastTrips; // 이전 여행
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/home/service/HomeService.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/service/HomeService.java
@@ -1,6 +1,8 @@
 package com.snapsplit.backend.feature.home.service;
 
 import com.snapsplit.backend.feature.home.dto.HomeResponse;
+import com.snapsplit.backend.feature.ongoingTrips.dto.OngoingTripResponse;
+import com.snapsplit.backend.feature.ongoingTrips.service.OngoingTripsService;
 import com.snapsplit.backend.feature.pastTrips.service.PastTripsService;
 import com.snapsplit.backend.feature.upcomingTrips.service.UpcomingTripsService;
 import com.snapsplit.backend.feature.pastTrips.dto.PastTripResponse;
@@ -9,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,14 +18,17 @@ public class HomeService {
 
     private final PastTripsService pastTripsService;
     private final UpcomingTripsService upcomingTripsService;
+    private final OngoingTripsService ongoingTripsService;
 
     public HomeResponse getHome(Long userId) {
         // 지난 여행: limit 5
         List<PastTripResponse> pastTrips = pastTripsService.getPastTrips(userId, 5);
         List<UpcomingTripResponse> upcomingTrips = upcomingTripsService.getUpcomingTrips(userId);
+        List<OngoingTripResponse> ongoingTrips = ongoingTripsService.getOngoingTrips(userId);
 
         return HomeResponse.builder()
                 .upcomingTrips(upcomingTrips)
+                .ongoingTrips(ongoingTrips)
                 .pastTrips(pastTrips)
                 .build();
     }

--- a/src/main/java/com/snapsplit/backend/feature/home/service/HomeService.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/service/HomeService.java
@@ -1,0 +1,31 @@
+package com.snapsplit.backend.feature.home.service;
+
+import com.snapsplit.backend.feature.home.dto.HomeResponse;
+import com.snapsplit.backend.feature.pastTrips.service.PastTripsService;
+import com.snapsplit.backend.feature.upcomingTrips.service.UpcomingTripsService;
+import com.snapsplit.backend.feature.pastTrips.dto.PastTripResponse;
+import com.snapsplit.backend.feature.upcomingTrips.dto.UpcomingTripResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+
+    private final PastTripsService pastTripsService;
+    private final UpcomingTripsService upcomingTripsService;
+
+    public HomeResponse getHome(Long userId) {
+        // 지난 여행: limit 5
+        List<PastTripResponse> pastTrips = pastTripsService.getPastTrips(userId, 5);
+        List<UpcomingTripResponse> upcomingTrips = upcomingTripsService.getUpcomingTrips(userId);
+
+        return HomeResponse.builder()
+                .upcomingTrips(upcomingTrips)
+                .pastTrips(pastTrips)
+                .build();
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/home/service/HomeService.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/service/HomeService.java
@@ -20,6 +20,7 @@ public class HomeService {
     private final UpcomingTripsService upcomingTripsService;
     private final OngoingTripsService ongoingTripsService;
 
+    // 기본 홈 정보 조회하기
     public HomeResponse getHome(Long userId) {
         // 지난 여행: limit 5
         List<PastTripResponse> pastTrips = pastTripsService.getPastTrips(userId, 5);

--- a/src/main/java/com/snapsplit/backend/feature/ongoingTrips/dto/OngoingTripResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/ongoingTrips/dto/OngoingTripResponse.java
@@ -1,0 +1,30 @@
+package com.snapsplit.backend.feature.ongoingTrips.dto;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class OngoingTripResponse {
+
+    private Long tripId;
+    private String tripName;
+    private String startDate;
+    private String endDate;
+    private String tripImage;
+    private List<String> countryNames;
+
+    public static OngoingTripResponse from(Trip trip, List<String> countryNames) {
+        return OngoingTripResponse.builder()
+                .tripId(trip.getId())
+                .tripName(trip.getTripName())
+                .startDate(trip.getStartDate().toString())
+                .endDate(trip.getEndDate().toString())
+                .tripImage(trip.getTripImage())
+                .countryNames(countryNames)
+                .build();
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/ongoingTrips/service/OngoingTripsService.java
+++ b/src/main/java/com/snapsplit/backend/feature/ongoingTrips/service/OngoingTripsService.java
@@ -1,0 +1,38 @@
+package com.snapsplit.backend.feature.ongoingTrips.service;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
+import com.snapsplit.backend.feature.ongoingTrips.dto.OngoingTripResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class OngoingTripsService {
+
+    private final TripMemberRepository tripMemberRepository;
+    private final TripCountryRepository tripCountryRepository;
+
+    public List<OngoingTripResponse> getOngoingTrips(Long userId) {
+        LocalDate today = LocalDate.now();
+
+        // 진행 중인 여행 조회
+        List<Trip> trips = tripMemberRepository.findOngoingTripsByUserId(userId, today);
+
+        // Trip → OngoingTripResponse 변환
+        return trips.stream()
+                .map(trip -> {
+                    List<String> countryNames = tripCountryRepository.findAllByTripId(trip.getId()).stream()
+                            .map(tc -> tc.getCountry().getCountryName())
+                            .collect(Collectors.toList());
+
+                    return OngoingTripResponse.from(trip, countryNames);
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### ✨ 개요
기본 홈화면에서 필요한 정보들을 한 번에 조회할 수 있는 기능 추가

### ✅ 작업 내용
- 다가오는 여행 리스트 (`upcomingTrips`) 조회
- 지난 여행 리스트 (`pastTrips`) 조회
- 현재 진행 중인 여행 리스트(`ongoingTrips`) 조회
- 각 여행별:
  - 국가 리스트
  - 여행 기간 (startDate, endDate)
  - 대표 이미지 (tripImage) 는 지난 여행만
- 홈 진입 시 요약 정보를 한 번에 응답하도록 설계

### 🔗 관련 API
- POST /home

### 📝 참고 사항
- 지난 여행은 기본적으로 최대 5개만 반환하도록 제한
- 여행 후 하단에 뜨는 정산 관련 여행 로직은 아직 미구현 상태로, 정산 기능 구현 후 수정 예정
- 대표 이미지 관련 로직은 아직 미구현 상태로, Snap 기능 구현 후 수정 예정
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 홈 화면에서 사용자의 예정된 여행, 진행 중인 여행, 지난 여행 목록을 한 번에 확인할 수 있는 엔드포인트가 추가되었습니다.
  * 진행 중인 여행 정보를 조회할 수 있는 기능이 새롭게 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->