### PR TITLE
[Feat] 공동 경비 추가하기

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/shared/repository/SharedRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/shared/repository/SharedRepository.java
@@ -1,0 +1,11 @@
+package com.snapsplit.backend.domain.shared.repository;
+
+import com.snapsplit.backend.domain.shared.entity.Shared;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SharedRepository extends JpaRepository<Shared, Long> {
+
+}

--- a/src/main/java/com/snapsplit/backend/domain/totalshared/entity/TotalShared.java
+++ b/src/main/java/com/snapsplit/backend/domain/totalshared/entity/TotalShared.java
@@ -32,4 +32,15 @@ public class TotalShared {
 
     @Column(name = "latest_modified", nullable = false)
     private LocalDate latestModified; // 마지막 수정일
+
+    // 경비 총액 업데이트용 setter
+    public void updateTotalSharedAmount(BigDecimal totalSharedAmount) {
+        this.totalSharedAmount = totalSharedAmount;
+    }
+
+    // 최신 입금일자 업데이트 용 setter
+    public void updateLatestModified(LocalDate latestModified) {
+        this.latestModified = latestModified;
+    }
+
 }

--- a/src/main/java/com/snapsplit/backend/domain/totalshared/repository/TotalSharedRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/totalshared/repository/TotalSharedRepository.java
@@ -1,7 +1,13 @@
 package com.snapsplit.backend.domain.totalshared.repository;
 
 import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
+import com.snapsplit.backend.domain.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TotalSharedRepository extends JpaRepository<TotalShared, Long> {
+
+    // trip_id와 currency가 일치하는 TotalShared 찾기
+    Optional<TotalShared> findByTripAndTotalSharedCurrency(Trip trip, String totalSharedCurrency);
 }

--- a/src/main/java/com/snapsplit/backend/feature/addTotalShared/controller/AddTotalSharedController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addTotalShared/controller/AddTotalSharedController.java
@@ -1,0 +1,37 @@
+package com.snapsplit.backend.feature.addTotalShared.controller;
+
+import com.snapsplit.backend.feature.addTotalShared.dto.AddTotalSharedRequest;
+import com.snapsplit.backend.feature.addTotalShared.dto.AddTotalSharedResponse;
+import com.snapsplit.backend.feature.addTotalShared.service.AddTotalSharedService;
+import com.snapsplit.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@RestController
+@RequestMapping("/trips/{tripId}/budget")
+@RequiredArgsConstructor
+public class AddTotalSharedController {
+
+    private final AddTotalSharedService addTotalSharedService;
+
+    @PostMapping("/add")
+    public ResponseEntity<ApiResponse<AddTotalSharedResponse>> addTotalShared(
+            @PathVariable Long tripId,
+            @RequestBody AddTotalSharedRequest request) {
+
+        try {
+            AddTotalSharedResponse response = addTotalSharedService.addTotalShared(tripId, request);
+            return ResponseEntity.ok(ApiResponse.success("공동경비가 성공적으로 추가되었습니다.", response));
+        } catch (IllegalArgumentException e) {
+            // trip_id에 해당하는 여행이 없는 경우
+            return ResponseEntity
+                    .badRequest()
+                    .body(ApiResponse.fail(400, e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/addTotalShared/controller/AddTotalSharedController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addTotalShared/controller/AddTotalSharedController.java
@@ -4,6 +4,7 @@ import com.snapsplit.backend.feature.addTotalShared.dto.AddTotalSharedRequest;
 import com.snapsplit.backend.feature.addTotalShared.dto.AddTotalSharedResponse;
 import com.snapsplit.backend.feature.addTotalShared.service.AddTotalSharedService;
 import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +20,8 @@ public class AddTotalSharedController {
 
     private final AddTotalSharedService addTotalSharedService;
 
+    // 공동 경비 추가하기
+    @Operation(summary = "공동 경비 추가", description = "공동 경비를 추가합니다.")
     @PostMapping("/add")
     public ResponseEntity<ApiResponse<AddTotalSharedResponse>> addTotalShared(
             @PathVariable Long tripId,

--- a/src/main/java/com/snapsplit/backend/feature/addTotalShared/dto/AddTotalSharedRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/addTotalShared/dto/AddTotalSharedRequest.java
@@ -1,0 +1,16 @@
+package com.snapsplit.backend.feature.addTotalShared.dto;
+
+import com.snapsplit.backend.domain.shared.entity.PaymentMethod;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+public class AddTotalSharedRequest {
+    private BigDecimal amount; // 경비 입금액
+    private String currency; // 경비 입금 통화
+    private PaymentMethod paymentMethod; // 경비 입금방식
+    private LocalDate createdAt; // 경비 입금일자
+}
+

--- a/src/main/java/com/snapsplit/backend/feature/addTotalShared/dto/AddTotalSharedResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/addTotalShared/dto/AddTotalSharedResponse.java
@@ -1,0 +1,19 @@
+package com.snapsplit.backend.feature.addTotalShared.dto;
+
+import com.snapsplit.backend.domain.shared.entity.PaymentMethod;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class AddTotalSharedResponse {
+    private Long sharedId; // 경비 총액 아이디
+    private Long tripId; // 여행 아이디
+    private BigDecimal amount; // 경비 총액
+    private String currency; // 통화
+    private PaymentMethod paymentMethod; // 입금 방식
+    private LocalDate createdAt; // 입금 일자
+}

--- a/src/main/java/com/snapsplit/backend/feature/addTotalShared/service/AddTotalSharedService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addTotalShared/service/AddTotalSharedService.java
@@ -1,0 +1,69 @@
+package com.snapsplit.backend.feature.addTotalShared.service;
+
+import com.snapsplit.backend.domain.shared.entity.Shared;
+import com.snapsplit.backend.domain.shared.repository.SharedRepository;
+import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
+import com.snapsplit.backend.domain.totalshared.repository.TotalSharedRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.feature.addTotalShared.dto.AddTotalSharedRequest;
+import com.snapsplit.backend.feature.addTotalShared.dto.AddTotalSharedResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AddTotalSharedService {
+
+    private final TripRepository tripRepository;
+    private final SharedRepository sharedRepository;
+    private final TotalSharedRepository totalSharedRepository;
+
+    @Transactional
+    public AddTotalSharedResponse addTotalShared(Long tripId, AddTotalSharedRequest request) {
+
+        // 해당 여행 찾기
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
+
+        // Shared 저장
+        Shared shared = Shared.builder()
+                .trip(trip)
+                .amount(request.getAmount())
+                .currency(request.getCurrency())
+                .paymentMethod(request.getPaymentMethod())
+                .createdAt(request.getCreatedAt())
+                .build();
+        sharedRepository.save(shared);
+
+        // TotalShared 업데이트 또는 신규 생성
+        TotalShared totalShared = totalSharedRepository.findByTripAndTotalSharedCurrency(trip, request.getCurrency())
+                .orElse(TotalShared.builder()
+                        .trip(trip)
+                        .totalSharedAmount(BigDecimal.ZERO)
+                        .totalSharedCurrency(request.getCurrency())
+                        .latestModified(LocalDate.now())
+                        .build());
+
+        // 경비총액과 최신 입금일자 변경
+        totalShared.updateTotalSharedAmount(totalShared.getTotalSharedAmount().add(request.getAmount()));
+        totalShared.updateLatestModified(LocalDate.now());
+
+        // 저장
+        totalSharedRepository.save(totalShared);
+
+        // 응답 빌드
+        return AddTotalSharedResponse.builder()
+                .sharedId(shared.getId())
+                .tripId(trip.getId())
+                .amount(shared.getAmount())
+                .currency(shared.getCurrency())
+                .paymentMethod(shared.getPaymentMethod())
+                .createdAt(shared.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/service/CreateTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/service/CreateTripService.java
@@ -88,6 +88,11 @@ public class CreateTripService {
                 .build();
         tripMemberRepository.save(sharedFundMember);
 
+        // 선택된 국가에 한국이 없을 경우 공동경비 통화에 기본적으로 KRW 들어가도록 추가
+        if (!currencySet.contains("KRW")) {
+            currencySet.add("KRW");
+        }
+
         // 선택된 여행 국가들에 대해
         // 각 국가의 통화 기준으로 초기 TotalShared(경비 총액) 엔티티 생성
         currencySet.forEach(currency -> {


### PR DESCRIPTION
### ✨ 개요
공동 경비 추가 기능 구현

### ✅ 세부 내용
- 공동 경비 충전(Add) 기능 구현
  - Shared 테이블에 입금 내역 저장
  - TotalShared 테이블에 총액 갱신
- 신규 여행 생성 시 기본 KRW 통화 자동 추가 로직 적용
- 컨트롤러에서 예외 발생 시 ApiResponse로 응답 처리

### 💸 관련 API
- POST /trips/{tripId}/budget/add

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여행별로 공용 경비를 추가할 수 있는 API가 도입되었습니다.
  * 공용 경비 추가 시 요청 및 응답을 위한 데이터 객체가 추가되었습니다.
  * 여행 및 통화별로 총 공용 경비를 관리하는 기능이 추가되었습니다.

* **버그 수정**
  * 여행 생성 시 선택된 국가에 "KRW"가 없을 경우에도 항상 "KRW"가 포함되도록 개선되었습니다.

* **기타**
  * 공용 경비 관련 저장소 및 서비스가 새롭게 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->