### PR TITLE
[Feat] 지출 추가/수정/삭제하기

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/expense/entity/Expense.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/entity/Expense.java
@@ -1,0 +1,60 @@
+package com.snapsplit.backend.domain.expense.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "expense")
+public class Expense {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "expense_id")
+    private Long id;
+
+    @Column(name = "trip_id", nullable = false)
+    private Long tripId;
+
+    @Column(name = "expense_date", nullable = true)
+    private LocalDate expenseDate;
+
+    @Column(name = "expense_day", nullable = false)
+    private Integer expenseDay;
+
+    @Column(name = "expense_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal expenseAmount;
+
+    @Column(name = "expense_currency", length = 10, nullable = false)
+    private String expenseCurrency;
+
+    @Column(name = "expense_krw", nullable = false, precision = 10, scale = 2)
+    private BigDecimal expenseKrw;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private Category category;
+
+    @Column(name = "expense_name", length = 50)
+    private String expenseName;
+
+    @Column(name = "expense_memo", columnDefinition = "TEXT")
+    private String expenseMemo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_method", nullable = false)
+    private PaymentMethod paymentMethod;
+
+    public enum Category {
+        FLIGHT, ACCOMMODATION, FOOD, TRANSPORTATION, TOUR, SHOPPING, OTHERS
+    }
+
+    public enum PaymentMethod {
+        CASH, CREDIT_CARD
+    }
+}

--- a/src/main/java/com/snapsplit/backend/domain/expense/entity/Pay.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/entity/Pay.java
@@ -1,0 +1,39 @@
+package com.snapsplit.backend.domain.expense.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "pay")
+public class Pay {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pay_id")
+    private Long id;
+
+    @Column(name = "expense_id", nullable = false)
+    private Long expenseId;
+
+    @Column(name = "payer_id", nullable = false)
+    private Long payerId;
+
+    @Column(name = "pay_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal payAmount;
+
+    @Column(name = "pay_amount_krw", nullable = false, precision = 10, scale = 2)
+    private BigDecimal payAmountKrw;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_type", nullable = false)
+    private MemberType memberType;
+
+    public enum MemberType {
+        USER, SHARED_FUND
+    }
+}

--- a/src/main/java/com/snapsplit/backend/domain/expense/entity/Split.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/entity/Split.java
@@ -1,0 +1,32 @@
+package com.snapsplit.backend.domain.expense.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "split")
+public class Split {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "split_id")
+    private Long id;
+
+    @Column(name = "expense_id", nullable = false)
+    private Long expenseId;
+
+    @Column(name = "splitter_id", nullable = false)
+    private Long splitterId;
+
+    @Column(name = "split_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal splitAmount;
+
+    @Column(name = "split_amount_krw", nullable = false, precision = 10, scale = 2)
+    private BigDecimal splitAmountKrw;
+}
+

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/ExpenseRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.expense.repository;
+
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.expense.repository;
+
+import com.snapsplit.backend.domain.expense.entity.Pay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PayRepository extends JpaRepository<Pay, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
@@ -2,6 +2,14 @@ package com.snapsplit.backend.domain.expense.repository;
 
 import com.snapsplit.backend.domain.expense.entity.Pay;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PayRepository extends JpaRepository<Pay, Long> {
+
+    @Modifying
+    @Query("DELETE FROM Pay p WHERE p.expenseId = :expenseId")
+    void deleteByExpenseId(@Param("expenseId") Long expenseId);
+
 }

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
@@ -2,6 +2,13 @@ package com.snapsplit.backend.domain.expense.repository;
 
 import com.snapsplit.backend.domain.expense.entity.Split;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SplitRepository extends JpaRepository<Split, Long> {
+    @Modifying
+    @Query("DELETE FROM Split s WHERE s.expenseId = :expenseId")
+    void deleteByExpenseId(@Param("expenseId") Long expenseId);
+
 }

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.expense.repository;
+
+import com.snapsplit.backend.domain.expense.entity.Split;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SplitRepository extends JpaRepository<Split, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
@@ -4,10 +4,10 @@ import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
 import com.snapsplit.backend.feature.addExpense.service.AddExpenseService;
 import com.snapsplit.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.persistence.EntityNotFoundException;
 
 import java.util.Map;
 
@@ -39,6 +39,10 @@ public class AddExpenseController {
             return ResponseEntity.badRequest().body(
                     ApiResponse.fail(400, e.getMessage())
             );
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(404).body(
+                    ApiResponse.fail(404, e.getMessage())
+            );
         }
     }
 
@@ -62,6 +66,10 @@ public class AddExpenseController {
             return ResponseEntity.badRequest().body(
                     ApiResponse.fail(400, e.getMessage())
             );
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(404).body(
+                    ApiResponse.fail(404, e.getMessage())
+            );
         }
     }
 
@@ -78,8 +86,7 @@ public class AddExpenseController {
             @RequestBody AddExpenseRequest request
     ) {
         try {
-            addExpenseService.deleteExpense(tripId, expenseId);
-            Long newExpenseId = addExpenseService.addExpense(tripId, request);
+            Long newExpenseId = addExpenseService.updateExpense(tripId, expenseId, request);
             Map<String, Long> response = Map.of("expenseId", newExpenseId);
 
             return ResponseEntity.ok(
@@ -89,6 +96,10 @@ public class AddExpenseController {
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(
                     ApiResponse.fail(400, e.getMessage())
+            );
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(404).body(
+                    ApiResponse.fail(404, e.getMessage())
             );
         }
     }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
@@ -66,4 +66,33 @@ public class AddExpenseController {
     }
 
 
+    //지출 수정
+    @PutMapping("/{expenseId}")
+    @Operation(
+            summary = "지출 수정",
+            description = "기존 지출 내역을 삭제하고, 새로운 지출 정보로 교체합니다."
+    )
+    public ResponseEntity<ApiResponse<Map<String, Long>>> updateExpense(
+            @PathVariable Long tripId,
+            @PathVariable Long expenseId,
+            @RequestBody AddExpenseRequest request
+    ) {
+        try {
+            addExpenseService.deleteExpense(tripId, expenseId);
+            Long newExpenseId = addExpenseService.addExpense(tripId, request);
+            Map<String, Long> response = Map.of("expenseId", newExpenseId);
+
+            return ResponseEntity.ok(
+                    ApiResponse.success("지출이 성공적으로 수정되었습니다.", response)
+            );
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(
+                    ApiResponse.fail(400, e.getMessage())
+            );
+        }
+    }
+
+
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
@@ -4,6 +4,7 @@ import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
 import com.snapsplit.backend.feature.addExpense.service.AddExpenseService;
 import com.snapsplit.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +27,7 @@ public class AddExpenseController {
     )
     public ResponseEntity<ApiResponse<Map<String, Long>>> addExpense(
             @PathVariable Long tripId,
-            @RequestBody AddExpenseRequest request
+            @RequestBody @Valid AddExpenseRequest request
     ){
         try {
             Long expenseId = addExpenseService.addExpense(tripId, request);
@@ -83,7 +84,7 @@ public class AddExpenseController {
     public ResponseEntity<ApiResponse<Map<String, Long>>> updateExpense(
             @PathVariable Long tripId,
             @PathVariable Long expenseId,
-            @RequestBody AddExpenseRequest request
+            @RequestBody @Valid AddExpenseRequest request
     ) {
         try {
             Long newExpenseId = addExpenseService.updateExpense(tripId, expenseId, request);

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
@@ -1,0 +1,42 @@
+package com.snapsplit.backend.feature.addExpense.controller;
+
+import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
+import com.snapsplit.backend.feature.addExpense.service.AddExpenseService;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/trips/{tripId}/expense")
+@RequiredArgsConstructor
+public class AddExpenseController {
+
+    private final AddExpenseService addExpenseService;
+
+    @PostMapping
+    @Operation(
+            summary = "여행 지출 추가",
+            description = "여행 중 발생한 개별 지출 내역을 등록합니다. 결제자와 분담자 정보를 함께 포함해야 합니다."
+    )
+    public ResponseEntity<ApiResponse<Map<String, Long>>> addExpense(
+            @PathVariable Long tripId,
+            @RequestBody AddExpenseRequest request
+    ){
+        try {
+            Long expenseId = addExpenseService.addExpense(tripId, request);
+            Map<String, Long> response = Map.of("expenseId", expenseId);
+            return ResponseEntity.ok(
+                    ApiResponse.success("지출이 성공적으로 등록되었습니다.", response)
+            );
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(
+                    ApiResponse.fail(400, e.getMessage())
+            );
+        }
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
@@ -47,14 +47,23 @@ public class AddExpenseController {
     @DeleteMapping("/{expenseId}")
     @Operation(
             summary = "지출 삭제",
-            description = "지출 ID를 통해 해당 지출과 관련된 모든 정보를 삭제합니다."
+            description = "특정 여행(tripId) 내 특정 지출(expenseId)을 삭제합니다. 관련된 Pay와 Split 내역도 함께 삭제됩니다."
     )
     public ResponseEntity<ApiResponse<Void>> deleteExpense(
             @PathVariable Long tripId,
             @PathVariable Long expenseId
     ) {
-        addExpenseService.deleteExpense(expenseId);
-        return ResponseEntity.ok(ApiResponse.success("지출이 성공적으로 삭제되었습니다.", null));
+        try {
+            addExpenseService.deleteExpense(tripId, expenseId);
+            return ResponseEntity.ok(
+                    ApiResponse.success("지출이 성공적으로 삭제되었습니다.", null)
+            );
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(
+                    ApiResponse.fail(400, e.getMessage())
+            );
+        }
     }
+
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
@@ -4,6 +4,7 @@ import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
 import com.snapsplit.backend.feature.addExpense.service.AddExpenseService;
 import com.snapsplit.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,9 +18,10 @@ public class AddExpenseController {
 
     private final AddExpenseService addExpenseService;
 
+    //지출 추가
     @PostMapping
     @Operation(
-            summary = "여행 지출 추가",
+            summary = "지출 추가",
             description = "여행 중 발생한 개별 지출 내역을 등록합니다. 결제자와 분담자 정보를 함께 포함해야 합니다."
     )
     public ResponseEntity<ApiResponse<Map<String, Long>>> addExpense(
@@ -39,4 +41,20 @@ public class AddExpenseController {
             );
         }
     }
+
+
+    //지출 삭제
+    @DeleteMapping("/{expenseId}")
+    @Operation(
+            summary = "지출 삭제",
+            description = "지출 ID를 통해 해당 지출과 관련된 모든 정보를 삭제합니다."
+    )
+    public ResponseEntity<ApiResponse<Void>> deleteExpense(
+            @PathVariable Long tripId,
+            @PathVariable Long expenseId
+    ) {
+        addExpenseService.deleteExpense(expenseId);
+        return ResponseEntity.ok(ApiResponse.success("지출이 성공적으로 삭제되었습니다.", null));
+    }
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
@@ -2,31 +2,46 @@ package com.snapsplit.backend.feature.addExpense.dto;
 
 import java.math.BigDecimal;
 import java.util.List;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 public record AddExpenseRequest(
+        @NotNull @Valid
         ExpenseDto expense,
+        @NotNull @Size(min=1)
         List<PayerDto> payers,
+        @NotNull @Size(min=1)
         List<SplitterDto> splitters
 ) {
 
     public record ExpenseDto(
+            @NotNull @Min(1)
             Integer day,
+            @NotNull @DecimalMin(value = "0.0", inclusive = false)
             BigDecimal amount,
+            @NotBlank
             String currency,
+            @NotNull @DecimalMin(value = "0.0", inclusive = false)
             BigDecimal exchangeRate,
+            @NotBlank
             String category,
             String expenseName,
             String expenseMemo,
+            @NotBlank
             String paymentMethod
     ) {}
 
     public record PayerDto(
+            @NotNull
             Long tripMemberId,
+            @NotNull @DecimalMin(value = "0.0", inclusive = false)
             BigDecimal payerAmount
     ) {}
 
     public record SplitterDto(
+            @NotNull
             Long tripMemberId,
+            @NotNull @DecimalMin(value = "0.0", inclusive = false)
             BigDecimal splitAmount
     ) {}
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
@@ -1,0 +1,32 @@
+package com.snapsplit.backend.feature.addExpense.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record AddExpenseRequest(
+        ExpenseDto expense,
+        List<PayerDto> payers,
+        List<SplitterDto> splitters
+) {
+
+    public record ExpenseDto(
+            Integer day,
+            BigDecimal amount,
+            String currency,
+            BigDecimal exchangeRate,
+            String category,
+            String expense_name,
+            String expense_memo,
+            String paymentMethod
+    ) {}
+
+    public record PayerDto(
+            Long tripMemberId,
+            BigDecimal payerAmount
+    ) {}
+
+    public record SplitterDto(
+            Long tripMemberId,
+            BigDecimal splitAmount
+    ) {}
+}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
@@ -15,8 +15,8 @@ public record AddExpenseRequest(
             String currency,
             BigDecimal exchangeRate,
             String category,
-            String expense_name,
-            String expense_memo,
+            String expenseName,
+            String expenseMemo,
             String paymentMethod
     ) {}
 

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -3,7 +3,6 @@ package com.snapsplit.backend.feature.addExpense.service;
 import com.snapsplit.backend.domain.expense.entity.*;
 import com.snapsplit.backend.domain.expense.repository.*;
 import com.snapsplit.backend.domain.tripmember.entity.TripMember;
-import com.snapsplit.backend.domain.expense.entity.Pay;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
 import jakarta.persistence.EntityNotFoundException;
@@ -57,8 +56,8 @@ public class AddExpenseService {
                         .expenseCurrency(info.currency())
                         .expenseKrw(expenseAmount.multiply(rate))
                         .category(Expense.Category.valueOf(info.category().toUpperCase()))
-                        .expenseName(info.expense_name())
-                        .expenseMemo(info.expense_memo())
+                        .expenseName(info.expenseName())
+                        .expenseMemo(info.expenseMemo())
                         .paymentMethod(Expense.PaymentMethod.valueOf(info.paymentMethod().toUpperCase()))
                         .build()
         );
@@ -113,5 +112,14 @@ public class AddExpenseService {
         splitRepository.deleteByExpenseId(expenseId);
         expenseRepository.deleteById(expenseId);
     }
+
+
+    //지출 수정
+    @Transactional
+    public Long updateExpense(Long tripId, Long expenseId, AddExpenseRequest request) {
+        deleteExpense(tripId, expenseId); // 기존 지출 삭제
+        return addExpense(tripId, request); // 새 지출 등록
+    }
+
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -18,6 +18,8 @@ public class AddExpenseService {
     private final PayRepository payRepository;
     private final SplitRepository splitRepository;
 
+
+    //지출 추가
     @Transactional
     public Long addExpense(Long tripId, AddExpenseRequest request) {
         var info = request.expense();
@@ -81,5 +83,14 @@ public class AddExpenseService {
         splitRepository.saveAll(splits);
 
         return expense.getId();
+    }
+
+
+    //지출 삭제
+    @Transactional
+    public void deleteExpense(Long expenseId) {
+        payRepository.deleteByExpenseId(expenseId);
+        splitRepository.deleteByExpenseId(expenseId);
+        expenseRepository.deleteById(expenseId);
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -3,6 +3,7 @@ package com.snapsplit.backend.feature.addExpense.service;
 import com.snapsplit.backend.domain.expense.entity.*;
 import com.snapsplit.backend.domain.expense.repository.*;
 import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -88,9 +89,18 @@ public class AddExpenseService {
 
     //지출 삭제
     @Transactional
-    public void deleteExpense(Long expenseId) {
+    public void deleteExpense(Long tripId, Long expenseId) {
+
+        Expense expense = expenseRepository.findById(expenseId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 지출이 존재하지 않습니다."));
+
+        if (!expense.getTripId().equals(tripId)) {
+            throw new IllegalArgumentException("여행 정보가 일치하지 않습니다.");
+        }
+
         payRepository.deleteByExpenseId(expenseId);
         splitRepository.deleteByExpenseId(expenseId);
         expenseRepository.deleteById(expenseId);
     }
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -2,6 +2,9 @@ package com.snapsplit.backend.feature.addExpense.service;
 
 import com.snapsplit.backend.domain.expense.entity.*;
 import com.snapsplit.backend.domain.expense.repository.*;
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import com.snapsplit.backend.domain.expense.entity.Pay;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +21,7 @@ public class AddExpenseService {
     private final ExpenseRepository expenseRepository;
     private final PayRepository payRepository;
     private final SplitRepository splitRepository;
-
+    private final TripMemberRepository tripMemberRepository;
 
     //지출 추가
     @Transactional
@@ -61,15 +64,23 @@ public class AddExpenseService {
         );
 
         // 결제자 저장
-        List<Pay> pays = request.payers().stream().map(payer ->
-                Pay.builder()
-                        .expenseId(expense.getId())
-                        .payerId(payer.tripMemberId())
-                        .payAmount(payer.payerAmount())
-                        .payAmountKrw(payer.payerAmount().multiply(rate))
-                        .memberType(Pay.MemberType.USER) // 기본값
-                        .build()
-        ).toList();
+        List<Pay> pays = request.payers().stream()
+                .map(payer -> {
+                    TripMember tripMember = tripMemberRepository.findById(payer.tripMemberId())
+                            .orElseThrow(() -> new EntityNotFoundException("해당 tripMember가 존재하지 않습니다."));
+
+                    Pay.MemberType memberType = (tripMember.getUser() == null)
+                            ? Pay.MemberType.SHARED_FUND
+                            : Pay.MemberType.USER;
+
+                    return Pay.builder()
+                            .expenseId(expense.getId())
+                            .payerId(payer.tripMemberId())
+                            .payAmount(payer.payerAmount())
+                            .payAmountKrw(payer.payerAmount().multiply(rate))
+                            .memberType(memberType)
+                            .build();
+                }).toList();
         payRepository.saveAll(pays);
 
         // 분담자 저장

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -1,0 +1,85 @@
+package com.snapsplit.backend.feature.addExpense.service;
+
+import com.snapsplit.backend.domain.expense.entity.*;
+import com.snapsplit.backend.domain.expense.repository.*;
+import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AddExpenseService {
+
+    private final ExpenseRepository expenseRepository;
+    private final PayRepository payRepository;
+    private final SplitRepository splitRepository;
+
+    @Transactional
+    public Long addExpense(Long tripId, AddExpenseRequest request) {
+        var info = request.expense();
+        BigDecimal rate = info.exchangeRate();
+        BigDecimal expenseAmount = info.amount();
+
+        // split 총합 검증
+        BigDecimal splitTotal = request.splitters().stream()
+                .map(AddExpenseRequest.SplitterDto::splitAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        if (!splitTotal.equals(expenseAmount)) {
+            throw new IllegalArgumentException("splitList의 금액 합계가 지출 금액과 일치하지 않습니다.");
+        }
+
+        // pay 총합 검증
+        BigDecimal payTotal = request.payers().stream()
+                .map(AddExpenseRequest.PayerDto::payerAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        if (!payTotal.equals(expenseAmount)) {
+            throw new IllegalArgumentException("payList의 결제 금액 합계가 지출 금액과 일치하지 않습니다.");
+        }
+
+        // 지출 저장
+        Expense expense = expenseRepository.save(
+                Expense.builder()
+                        .tripId(tripId)
+                        .expenseDay(info.day())
+                        .expenseAmount(expenseAmount)
+                        .expenseCurrency(info.currency())
+                        .expenseKrw(expenseAmount.multiply(rate))
+                        .category(Expense.Category.valueOf(info.category().toUpperCase()))
+                        .expenseName(info.expense_name())
+                        .expenseMemo(info.expense_memo())
+                        .paymentMethod(Expense.PaymentMethod.valueOf(info.paymentMethod().toUpperCase()))
+                        .build()
+        );
+
+        // 결제자 저장
+        List<Pay> pays = request.payers().stream().map(payer ->
+                Pay.builder()
+                        .expenseId(expense.getId())
+                        .payerId(payer.tripMemberId())
+                        .payAmount(payer.payerAmount())
+                        .payAmountKrw(payer.payerAmount().multiply(rate))
+                        .memberType(Pay.MemberType.USER) // 기본값
+                        .build()
+        ).toList();
+        payRepository.saveAll(pays);
+
+        // 분담자 저장
+        List<Split> splits = request.splitters().stream().map(splitter ->
+                Split.builder()
+                        .expenseId(expense.getId())
+                        .splitterId(splitter.tripMemberId())
+                        .splitAmount(splitter.splitAmount())
+                        .splitAmountKrw(splitter.splitAmount().multiply(rate))
+                        .build()
+        ).toList();
+        splitRepository.saveAll(splits);
+
+        return expense.getId();
+    }
+}


### PR DESCRIPTION
### ✨ 개요
여행 개별 지출 추가/수정/삭제 기능 구현

### ✅ 작업 내용
- 지출 추가 로직
  - 지출 추가 페이지를 열 때 백엔드가 환율 조회 API(외부 API 연동)로 환율 정보를 프론트에 전달
  - 프론트는 해당 시점의 환율 정보를 지출 등록 요청에 포함하여 POST
  - 백엔드는 전달받은 환율값을 기반으로 expense_krw를 계산해 DB에 저장 (환율은 저장하지 않음)
- 지출 수정 로직
  - 기존 expense, pay, split 레코드를 삭제하고 새로 저장하는 방식으로 처리
  - 수정시점 기준의 환율이 새로 적용됨
- 지출 삭제 로직
  - expenseId 기준으로 expense, pay, split 모두 삭제됨
  - 지출 삭제 중 하나라도 실패하면 전체 롤백되게 @Transactional 처리

### 📌 향후 추가 사항
- 이후 정산로직 구현시 정산 영수증 출력 후 지난 시점의 지출에 대해서는 추가/수정/삭제를 제한해야함
- expense_date는 nullable로 설정해둠, 추후 date 사용하는 로직이 없다면 아예 제거하기
- 영수증으로 지출 등록 기능 추가하기
- 지출 추가하기 페이지 불러오기는 환율 api 완료 후 이어서 작업

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 여행 경비 관리 기능이 추가되었습니다. 사용자는 경비를 추가, 수정, 삭제할 수 있으며, 각 경비에 대한 지불자와 분배자를 지정할 수 있습니다.
  * 경비 추가 시 금액, 통화, 카테고리, 결제 방법 등 상세 정보를 입력할 수 있습니다.
  * 경비 삭제 및 수정 기능이 제공되어 여행 내 경비 내역을 편리하게 관리할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->