### PR TITLE
[Feat] 로그인 응답에 유저 정보포함

### DIFF
--- a/src/main/java/com/snapsplit/backend/feature/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/controller/KakaoAuthController.java
@@ -34,7 +34,7 @@ public class KakaoAuthController {
                     "미가입된 회원일 시 회원가입 후 로그인하고 " +
                     "가입된 회원일 시 바로 로그인합니다.")
     @PostMapping("/kakao/login")
-    public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(@RequestParam String code) {
+    public ResponseEntity<ApiResponse<LoginResponse>> kakaoLogin(@RequestParam String code) {
         try {
             // 인가 코드로 카카오 access token 받기
             KakaoTokenResponse tokenResponse = kakaoOAuthService.getToken(code);
@@ -51,12 +51,17 @@ public class KakaoAuthController {
 
             refreshTokenService.save(user, refreshToken, jwtUtil.getRefreshTokenExpiry());
 
-            // access token 및 refresh token dto
-            TokenResponse jwtResponse = new TokenResponse(accessToken, refreshToken);
+            LoginResponse response = LoginResponse.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .userId(user.getId())
+                    .name(user.getName())
+                    .profileImage(user.getProfileImage())
+                    .userCode(user.getUserCode())
+                    .build();
 
-            return ResponseEntity.ok(
-                    ApiResponse.success("카카오 로그인 성공", jwtResponse)
-            );
+            return ResponseEntity.ok(ApiResponse.success("카카오 로그인 성공", response));
+
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(ApiResponse.fail(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));

--- a/src/main/java/com/snapsplit/backend/feature/auth/dto/LoginResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/auth/dto/LoginResponse.java
@@ -1,0 +1,17 @@
+package com.snapsplit.backend.feature.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+    private Long userId;
+    private String name;
+    private String profileImage;
+    private String userCode;
+}


### PR DESCRIPTION
### ✨ 개요
카카오 OAuth 로그인 응답에 사용자 정보 포함

### ✅ 세부 내용
- 기존 로그인 응답(TokenResponse) → LoginResponseDto로 변경
- accessToken, refreshToken 외에 다음 유저 정보 추가 포함:
  - userId
  - name
  - profileImage
  - userCode
- 로그인 응답 DTO 신설 및 컨트롤러 응답 로직 수정

### 🔐 관련 API
- POST /auth/kakao/login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카카오 로그인 시, 응답에 액세스 토큰과 리프레시 토큰 외에 사용자 ID, 이름, 프로필 이미지, 유저 코드 등 추가 정보가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->