### PR TITLE
[Feat] 환율 조회 시 외부 API 응답 실패에 대비한 Redis 캐시 fallback 처리

### DIFF
--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
@@ -19,6 +19,7 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -60,16 +61,20 @@ public class ExchangeRateService {
                 log.warn("환율 API 응답이 비어 있음. Redis 캐시 fallback 시도");
 
                 String redisKey = "exchange:" + base.toUpperCase();
-                String cachedJson = redisTemplate.opsForValue().get(redisKey);
-
-                if (cachedJson != null) {
-                    ExchangeRateResponse cached = objectMapper.readValue(cachedJson, ExchangeRateResponse.class);
-                    log.info("Redis에서 환율 캐시 응답 반환: {}", cached);
-                    return cached;
+                try {
+                    String cachedJson = redisTemplate.opsForValue().get(redisKey);
+                    if (cachedJson != null) {
+                        ExchangeRateResponse cached = objectMapper.readValue(cachedJson, ExchangeRateResponse.class);
+                        log.info("Redis에서 환율 캐시 응답 반환: {}", cached);
+                        return cached;
+                    }
+                } catch (Exception e) {
+                    log.warn("Redis 캐시 조회 실패. 무시하고 예외 처리 진행", e);
                 }
 
                 throw new RuntimeException("환율 API 응답이 비어있고, Redis 캐시도 없습니다.");
             }
+
         } catch (ResourceAccessException e) {
             throw new RuntimeException("환율 API 서버에 연결할 수 없습니다.", e);
         } catch (HttpClientErrorException | HttpServerErrorException e) {
@@ -118,7 +123,7 @@ public class ExchangeRateService {
         // Redis에 저장
         try {
             String json = objectMapper.writeValueAsString(result);
-            redisTemplate.opsForValue().set("exchange:" + base.toUpperCase(), json);
+            redisTemplate.opsForValue().set("exchange:" + base.toUpperCase(), json, Duration.ofHours(24));
             log.info("Redis에 환율 저장 완료: {}", json);
         } catch (Exception e) {
             log.warn("Redis 저장 실패. 무시하고 진행", e);

--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
@@ -1,5 +1,6 @@
 package com.snapsplit.backend.feature.getExchangeRate.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snapsplit.backend.feature.getExchangeRate.dto.ExchangeRateResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +9,7 @@ import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
 import net.minidev.json.parser.ParseException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
@@ -28,6 +30,8 @@ import java.time.format.DateTimeFormatter;
 public class ExchangeRateService {
 
     private final HolidayService holidayService;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper; // JSON 직렬화/역직렬화용
 
     @Value("${exchange-rate.auth-key}")
     private String authKey;
@@ -51,8 +55,20 @@ public class ExchangeRateService {
         String response;
         try {
             response = restTemplate.getForObject(url, String.class);
+
             if (response == null || response.trim().isEmpty()) {
-                throw new RuntimeException("환율 API 응답이 비어있습니다.");
+                log.warn("환율 API 응답이 비어 있음. Redis 캐시 fallback 시도");
+
+                String redisKey = "exchange:" + base.toUpperCase();
+                String cachedJson = redisTemplate.opsForValue().get(redisKey);
+
+                if (cachedJson != null) {
+                    ExchangeRateResponse cached = objectMapper.readValue(cachedJson, ExchangeRateResponse.class);
+                    log.info("Redis에서 환율 캐시 응답 반환: {}", cached);
+                    return cached;
+                }
+
+                throw new RuntimeException("환율 API 응답이 비어있고, Redis 캐시도 없습니다.");
             }
         } catch (ResourceAccessException e) {
             throw new RuntimeException("환율 API 서버에 연결할 수 없습니다.", e);
@@ -93,11 +109,23 @@ public class ExchangeRateService {
             rate = rate.divide(BigDecimal.valueOf(100));
         }
 
-        return ExchangeRateResponse.builder()
+        ExchangeRateResponse result = ExchangeRateResponse.builder()
                 .base(base.toUpperCase())
                 .rateToKrw(rate.doubleValue())
                 .date(searchDate)
                 .build();
+
+        // Redis에 저장
+        try {
+            String json = objectMapper.writeValueAsString(result);
+            redisTemplate.opsForValue().set("exchange:" + base.toUpperCase(), json);
+            log.info("Redis에 환율 저장 완료: {}", json);
+        } catch (Exception e) {
+            log.warn("Redis 저장 실패. 무시하고 진행", e);
+        }
+
+        return result;
+
     }
 
     // 비영업일 보정


### PR DESCRIPTION
### ✨ 개요
환율 조회 시 외부 API 응답이 비어있는 경우를 대비한 예외 처리 및 캐시 fallback 로직 추가

### ✅ 작업 내용
- 환율 API 응답이 비영업일 보정 후 요청 보냈음에도 비어있는 경우, Redis에서 마지막 캐시된 환율 응답을 반환
- 응답 캐시 저장 시 TTL 24시간 설정
- 캐시 미존재 시에는 기존과 동일하게 예외 발생 처리
- 로그로 캐시 사용 여부 확인 가능하도록 추가

### 🔐 관련 로직
- `ExchangeRateService.fetchExchangeRate()`

### 📌 기타 참고
- holidayService를 통한 비영업일 보정은 그대로 유지됨
- 캐시된 환율 응답은 날짜(`date`) 필드로 구분 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 환율 정보를 조회할 때 외부 API 응답이 없을 경우, Redis 캐시에서 환율 정보를 불러오는 기능이 추가되었습니다.
  * 성공적으로 환율 정보를 조회하면 해당 정보가 Redis 캐시에 저장되어 다음 조회 시 더 빠르게 제공됩니다.

* **버그 수정**
  * 외부 API와 캐시 모두에서 환율 정보를 가져올 수 없을 때 명확한 오류 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->