### PR TITLE
[Feat] 여행 접근 권한 체크 AOP 선행 로직 구현

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/shared/entity/Shared.java
+++ b/src/main/java/com/snapsplit/backend/domain/shared/entity/Shared.java
@@ -27,6 +27,9 @@ public class Shared {
     @Column(name = "shared_amount", nullable = false, precision = 10, scale = 2)
     private BigDecimal amount; // 경비 입금액
 
+    @Column(name = "shared_amount_krw", nullable = false)
+    private BigDecimal amountKRW; // 한화 환산 금액
+
     @Column(name = "shared_currency", length = 10, nullable = false)
     private String currency; // 경비 입금 통화
 

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
@@ -2,6 +2,7 @@ package com.snapsplit.backend.feature.addExpense.controller;
 
 import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
 import com.snapsplit.backend.feature.addExpense.service.AddExpenseService;
+import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -25,6 +26,7 @@ public class AddExpenseController {
             summary = "지출 추가",
             description = "여행 중 발생한 개별 지출 내역을 등록합니다. 결제자와 분담자 정보를 함께 포함해야 합니다."
     )
+    @CheckTripMember
     public ResponseEntity<ApiResponse<Map<String, Long>>> addExpense(
             @PathVariable Long tripId,
             @RequestBody @Valid AddExpenseRequest request
@@ -54,6 +56,7 @@ public class AddExpenseController {
             summary = "지출 삭제",
             description = "특정 여행(tripId) 내 특정 지출(expenseId)을 삭제합니다. 관련된 Pay와 Split 내역도 함께 삭제됩니다."
     )
+    @CheckTripMember
     public ResponseEntity<ApiResponse<Void>> deleteExpense(
             @PathVariable Long tripId,
             @PathVariable Long expenseId
@@ -81,6 +84,7 @@ public class AddExpenseController {
             summary = "지출 수정",
             description = "기존 지출 내역을 삭제하고, 새로운 지출 정보로 교체합니다."
     )
+    @CheckTripMember
     public ResponseEntity<ApiResponse<Map<String, Long>>> updateExpense(
             @PathVariable Long tripId,
             @PathVariable Long expenseId,

--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
@@ -42,7 +42,7 @@ public class ExchangeRateService {
         factory.setConnectTimeout(timeout);
         factory.setReadTimeout(timeout);
         restTemplate.setRequestFactory(factory);
-        
+
         String url = "https://oapi.koreaexim.go.kr/site/program/financial/exchangeJSON"
                 + "?authkey=" + authKey
                 + "&searchdate=" + searchDate

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/controller/AddTotalSharedController.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/controller/AddTotalSharedController.java
@@ -3,6 +3,7 @@ package com.snapsplit.backend.feature.updateTotalShared.controller;
 import com.snapsplit.backend.feature.updateTotalShared.dto.AddTotalSharedRequest;
 import com.snapsplit.backend.feature.updateTotalShared.dto.AddTotalSharedResponse;
 import com.snapsplit.backend.feature.updateTotalShared.service.AddTotalSharedService;
+import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
 import jakarta.persistence.OptimisticLockException;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +25,7 @@ public class AddTotalSharedController {
     // 공동 경비 추가하기
     @Operation(summary = "공동 경비 추가", description = "공동 경비를 추가합니다.")
     @PostMapping("/add")
+    @CheckTripMember
     public ResponseEntity<ApiResponse<AddTotalSharedResponse>> addTotalShared(
             @PathVariable Long tripId,
             @RequestBody AddTotalSharedRequest request) {

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/controller/RemoveTotalSharedController.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/controller/RemoveTotalSharedController.java
@@ -3,6 +3,7 @@ package com.snapsplit.backend.feature.updateTotalShared.controller;
 import com.snapsplit.backend.feature.updateTotalShared.dto.AddTotalSharedRequest;
 import com.snapsplit.backend.feature.updateTotalShared.dto.AddTotalSharedResponse;
 import com.snapsplit.backend.feature.updateTotalShared.service.RemoveTotalSharedService;
+import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.persistence.OptimisticLockException;
@@ -24,6 +25,7 @@ public class RemoveTotalSharedController {
     // 공동 경비 빼기
     @Operation(summary = "공동 경비 빼기", description = "공동 경비를 회수합니다.")
     @PostMapping("/remove")
+    @CheckTripMember
     public ResponseEntity<ApiResponse<AddTotalSharedResponse>> removeTotalShared(
             @PathVariable Long tripId,
             @RequestBody AddTotalSharedRequest request) {

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/dto/AddTotalSharedRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/dto/AddTotalSharedRequest.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 @Data
 public class AddTotalSharedRequest {
     private BigDecimal amount; // 경비 입금액
+    private BigDecimal exchangeRate; // 환율
     private String currency; // 경비 입금 통화
     private PaymentMethod paymentMethod; // 경비 입금방식
     private LocalDate createdAt; // 경비 입금일자

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/AddTotalSharedService.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/AddTotalSharedService.java
@@ -30,10 +30,14 @@ public class AddTotalSharedService {
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
 
+        // 환율 반영한 한화 금액 계산
+        BigDecimal amountKRW = request.getAmount().multiply(request.getExchangeRate());
+
         // Shared 저장
         Shared shared = Shared.builder()
                 .trip(trip)
                 .amount(request.getAmount())
+                .amountKRW(amountKRW)
                 .currency(request.getCurrency())
                 .paymentMethod(request.getPaymentMethod())
                 .createdAt(request.getCreatedAt())

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/RemoveTotalSharedService.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/RemoveTotalSharedService.java
@@ -40,11 +40,14 @@ public class RemoveTotalSharedService {
             throw new IllegalArgumentException("회수 금액이 현재 공동경비 총액을 초과할 수 없습니다.");
         }
 
+        // 환율 반영한 한화 금액 계산
+        BigDecimal amountKRW = request.getAmount().multiply(request.getExchangeRate());
 
         // Shared에 음수 금액으로 회수 내역 저장
         Shared shared = Shared.builder()
                 .trip(trip)
                 .amount(request.getAmount().negate()) // 음수 처리
+                .amountKRW(amountKRW)
                 .currency(request.getCurrency())
                 .paymentMethod(request.getPaymentMethod())
                 .createdAt(request.getCreatedAt())

--- a/src/main/java/com/snapsplit/backend/global/aop/CheckTripMember.java
+++ b/src/main/java/com/snapsplit/backend/global/aop/CheckTripMember.java
@@ -1,0 +1,9 @@
+package com.snapsplit.backend.global.aop;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CheckTripMember {
+}

--- a/src/main/java/com/snapsplit/backend/global/aop/TripAuthorizationAspect.java
+++ b/src/main/java/com/snapsplit/backend/global/aop/TripAuthorizationAspect.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.*;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
 
 @Aspect
@@ -23,8 +24,25 @@ public class TripAuthorizationAspect {
     @Pointcut("@annotation(com.snapsplit.backend.global.aop.CheckTripMember)")
     public void checkTripMemberPointcut() {}
 
-    @Around("checkTripMemberPointcut() && args(tripId,..)")
-    public Object validateTripMember(ProceedingJoinPoint joinPoint, Long tripId) throws Throwable {
+    @Around("checkTripMemberPointcut()")
+    public Object validateTripMember(ProceedingJoinPoint joinPoint) throws Throwable {
+        // 파라미터 이름, 값 모두 가져오기
+        Object[] args = joinPoint.getArgs();
+        String[] paramNames = ((MethodSignature) joinPoint.getSignature()).getParameterNames();
+
+        Long tripId = null;
+
+        for (int i = 0; i < paramNames.length; i++) {
+            if ("tripId".equals(paramNames[i]) && args[i] instanceof Long) {
+                tripId = (Long) args[i];
+                break;
+            }
+        }
+
+        if (tripId == null) {
+            throw new IllegalArgumentException("tripId 파라미터를 찾을 수 없습니다.");
+        }
+
         Long userId = securityUtil.getCurrentUserId();
 
         Trip trip = Trip.builder().id(tripId).build();
@@ -38,5 +56,4 @@ public class TripAuthorizationAspect {
 
         return joinPoint.proceed();
     }
-
 }

--- a/src/main/java/com/snapsplit/backend/global/aop/TripAuthorizationAspect.java
+++ b/src/main/java/com/snapsplit/backend/global/aop/TripAuthorizationAspect.java
@@ -1,0 +1,42 @@
+package com.snapsplit.backend.global.aop;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
+import com.snapsplit.backend.domain.user.entity.User;
+import com.snapsplit.backend.global.exception.ForbiddenException;
+import com.snapsplit.backend.global.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TripAuthorizationAspect {
+
+    private final TripMemberRepository tripMemberRepository;
+    private final SecurityUtil securityUtil;
+
+    @Pointcut("@annotation(com.snapsplit.backend.global.aop.CheckTripMember)")
+    public void checkTripMemberPointcut() {}
+
+    @Around("checkTripMemberPointcut() && args(tripId,..)")
+    public Object validateTripMember(ProceedingJoinPoint joinPoint, Long tripId) throws Throwable {
+        Long userId = securityUtil.getCurrentUserId();
+
+        Trip trip = Trip.builder().id(tripId).build();
+        User user = User.builder().id(userId).build();
+
+        boolean isMember = tripMemberRepository.existsByTripAndUser(trip, user);
+
+        if (!isMember) {
+            throw new ForbiddenException("해당 여행에 접근할 권한이 없습니다.");
+        }
+
+        return joinPoint.proceed();
+    }
+
+}

--- a/src/main/java/com/snapsplit/backend/global/exception/ForbiddenException.java
+++ b/src/main/java/com/snapsplit/backend/global/exception/ForbiddenException.java
@@ -1,0 +1,12 @@
+package com.snapsplit.backend.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.snapsplit.backend.global.exception;
+
+import com.snapsplit.backend.global.response.ApiResponse;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleForbidden(ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.fail(403, e.getMessage()));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNotFound(EntityNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.fail(404, e.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBadRequest(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(400, e.getMessage()));
+    }
+
+    // 그 외 처리 안 한 예외들
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneric(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(500, "서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
@@ -15,6 +15,12 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(403, e.getMessage()));
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnauthorized(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.fail(401, e.getMessage()));
+    }
+
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleNotFound(EntityNotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)

--- a/src/main/java/com/snapsplit/backend/global/exception/UnauthorizedException.java
+++ b/src/main/java/com/snapsplit/backend/global/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.snapsplit.backend.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/global/security/SecurityUtil.java
+++ b/src/main/java/com/snapsplit/backend/global/security/SecurityUtil.java
@@ -1,0 +1,30 @@
+package com.snapsplit.backend.global.security;
+
+import com.snapsplit.backend.global.exception.UnauthorizedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SecurityUtil {
+
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            log.warn("인증 정보 없음: SecurityContextHolder 비어있음");
+            throw new UnauthorizedException("로그인이 필요합니다.");
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (!(principal instanceof CustomUserPrincipal)) {
+            log.error("예상하지 못한 인증 객체 타입: {}", principal.getClass());
+            throw new UnauthorizedException("올바른 사용자 정보가 아닙니다.");
+        }
+
+        return ((CustomUserPrincipal) principal).getId();
+    }
+}


### PR DESCRIPTION
### ✨ 개요  
여행 관련 API 요청 시, 로그인한 사용자가 해당 여행(trip)의 멤버인지 선행 검증하는 AOP 기반 접근 제어 로직을 구현

### ✅ 세부 내용
- `@CheckTripMember` 커스텀 어노테이션 생성
- AOP를 이용해 tripId 파라미터 기반 멤버십 검증 로직 실행
- `TripMemberRepository.existsByTripAndUser()`를 활용해 현재 로그인 유저의 trip 접근 권한 확인
- 검증 실패 시 `ForbiddenException` 발생 및 403 상태 응답 처리
- `GlobalExceptionHandler`를 통해 모든 예외를 `ApiResponse` 형식으로 통일

### 📝 참고 사항
- 추후 `tripId`를 기반으로 이뤄지는 로직에서는 모두 적용할 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 여행 멤버십 검증을 위한 어노테이션과 권한 검사 기능이 추가되어, 여행 관련 API 접근 시 멤버 여부를 자동으로 확인합니다.
  * 금액 입력 시 환율을 적용해 원화(KRW) 금액이 자동으로 계산 및 저장됩니다.
  * 전역 예외 처리 기능이 도입되어, 인증, 인가, 입력 오류 발생 시 일관된 에러 메시지와 상태 코드가 반환됩니다.

* **버그 수정**
  * 일부 불필요한 공백이 제거되었습니다.

* **문서화**
  * API 오류 응답 및 인증 관련 동작이 명확하게 안내됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->