### PR TITLE
[Feat] 지출 추가 - expenseDate 기반 수정 및 공동경비 잔액 반영

### DIFF
--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
@@ -34,14 +34,14 @@ public record AddExpenseRequest(
 
     public record PayerDto(
             @NotNull
-            Long tripMemberId,
+            Long memberId,
             @NotNull @DecimalMin(value = "0.0", inclusive = false)
             BigDecimal payerAmount
     ) {}
 
     public record SplitterDto(
             @NotNull
-            Long tripMemberId,
+            Long memberId,
             @NotNull @DecimalMin(value = "0.0", inclusive = false)
             BigDecimal splitAmount
     ) {}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -18,6 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -43,11 +46,21 @@ public class AddExpenseService {
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
 
+        // 모든 payer의 TripMember를 한 번에 조회
+        List<Long> payerMemberIds = request.payers().stream()
+                .map(AddExpenseRequest.PayerDto::memberId)
+                .toList();
+        Map<Long, TripMember> tripMemberMap = tripMemberRepository.findAllById(payerMemberIds)
+                .stream()
+                .collect(Collectors.toMap(TripMember::getId, Function.identity()));
+
         // 공동경비 제외한 사용자 pay 총합 계산
         BigDecimal userPayTotal = request.payers().stream()
                 .filter(p -> {
-                    TripMember tripMember = tripMemberRepository.findById(p.memberId())
-                            .orElseThrow(() -> new EntityNotFoundException("해당 tripMember가 존재하지 않습니다."));
+                    TripMember tripMember = tripMemberMap.get(p.memberId());
+                    if (tripMember == null) {
+                        throw new EntityNotFoundException("해당 tripMember가 존재하지 않습니다.");
+                    }
                     return tripMember.getUser() != null;
                 })
                 .map(AddExpenseRequest.PayerDto::payerAmount)
@@ -119,7 +132,7 @@ public class AddExpenseService {
                                 .trip(trip)
                                 .amount(used.negate())
                                 .currency(info.currency())
-                                .paymentMethod(PaymentMethod.valueOf(info.paymentMethod().trim().toLowerCase()))
+                                .paymentMethod(parsePaymentMethod(info.paymentMethod()))
                                 .createdAt(java.time.LocalDate.now())
                                 .build());
                     }
@@ -171,6 +184,14 @@ public class AddExpenseService {
     public Long updateExpense(Long tripId, Long expenseId, AddExpenseRequest request) {
         deleteExpense(tripId, expenseId); // 기존 지출 삭제
         return addExpense(tripId, request); // 새 지출 등록
+    }
+
+    private PaymentMethod parsePaymentMethod(String value) {
+        try {
+            return PaymentMethod.valueOf(value.trim().toLowerCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 결제 방식입니다: " + value);
+        }
     }
 
 

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -65,7 +65,7 @@ public class AddExpenseService {
         // 결제자 저장
         List<Pay> pays = request.payers().stream()
                 .map(payer -> {
-                    TripMember tripMember = tripMemberRepository.findById(payer.tripMemberId())
+                    TripMember tripMember = tripMemberRepository.findById(payer.memberId())
                             .orElseThrow(() -> new EntityNotFoundException("해당 tripMember가 존재하지 않습니다."));
 
                     Pay.MemberType memberType = (tripMember.getUser() == null)
@@ -74,7 +74,7 @@ public class AddExpenseService {
 
                     return Pay.builder()
                             .expenseId(expense.getId())
-                            .payerId(payer.tripMemberId())
+                            .payerId(payer.memberId())
                             .payAmount(payer.payerAmount())
                             .payAmountKrw(payer.payerAmount().multiply(rate))
                             .memberType(memberType)
@@ -86,7 +86,7 @@ public class AddExpenseService {
         List<Split> splits = request.splitters().stream().map(splitter ->
                 Split.builder()
                         .expenseId(expense.getId())
-                        .splitterId(splitter.tripMemberId())
+                        .splitterId(splitter.memberId())
                         .splitAmount(splitter.splitAmount())
                         .splitAmountKrw(splitter.splitAmount().multiply(rate))
                         .build()

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -2,6 +2,12 @@ package com.snapsplit.backend.feature.addExpense.service;
 
 import com.snapsplit.backend.domain.expense.entity.*;
 import com.snapsplit.backend.domain.expense.repository.*;
+import com.snapsplit.backend.domain.shared.entity.PaymentMethod;
+import com.snapsplit.backend.domain.shared.entity.Shared;
+import com.snapsplit.backend.domain.shared.repository.SharedRepository;
+import com.snapsplit.backend.domain.totalshared.repository.TotalSharedRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
 import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
@@ -21,6 +27,10 @@ public class AddExpenseService {
     private final PayRepository payRepository;
     private final SplitRepository splitRepository;
     private final TripMemberRepository tripMemberRepository;
+    private final SharedRepository sharedRepository;
+    private final TotalSharedRepository totalSharedRepository;
+    private final TripRepository tripRepository;
+
 
     //지출 추가
     @Transactional
@@ -29,14 +39,29 @@ public class AddExpenseService {
         BigDecimal rate = info.exchangeRate();
         BigDecimal expenseAmount = info.amount();
 
-        // split 총합 검증
+        // Trip 객체 조회 (공동경비 조회 및 Shared 저장용으로 사용)
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
+
+        // 공동경비 제외한 사용자 pay 총합 계산
+        BigDecimal userPayTotal = request.payers().stream()
+                .filter(p -> {
+                    TripMember tripMember = tripMemberRepository.findById(p.memberId())
+                            .orElseThrow(() -> new EntityNotFoundException("해당 tripMember가 존재하지 않습니다."));
+                    return tripMember.getUser() != null;
+                })
+                .map(AddExpenseRequest.PayerDto::payerAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // split 총합 계산
         BigDecimal splitTotal = request.splitters().stream()
                 .map(AddExpenseRequest.SplitterDto::splitAmount)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        if (!splitTotal.equals(expenseAmount)) {
-            throw new IllegalArgumentException("splitList의 금액 합계가 지출 금액과 일치하지 않습니다.");
+        if (!splitTotal.equals(userPayTotal)) {
+            throw new IllegalArgumentException("splitList의 금액 합계가 사용자 결제 금액과 일치하지 않습니다.");
         }
+
 
         // pay 총합 검증
         BigDecimal payTotal = request.payers().stream()
@@ -62,7 +87,7 @@ public class AddExpenseService {
                         .build()
         );
 
-        // 결제자 저장
+        // 결제자 저장 & 공동 경비 처리
         List<Pay> pays = request.payers().stream()
                 .map(payer -> {
                     TripMember tripMember = tripMemberRepository.findById(payer.memberId())
@@ -71,6 +96,33 @@ public class AddExpenseService {
                     Pay.MemberType memberType = (tripMember.getUser() == null)
                             ? Pay.MemberType.SHARED_FUND
                             : Pay.MemberType.USER;
+
+                    // 공동경비 결제자 처리
+                    if (memberType == Pay.MemberType.SHARED_FUND) {
+                        var totalShared = totalSharedRepository.findByTripAndTotalSharedCurrency(trip, info.currency())
+                                .orElseThrow(() -> new IllegalArgumentException("공동경비가 존재하지 않습니다."));
+
+                        BigDecimal current = totalShared.getTotalSharedAmount();
+                        BigDecimal used = payer.payerAmount();
+
+                        if (current.compareTo(used) < 0) {
+                            throw new IllegalArgumentException("공동경비 잔액이 부족합니다.");
+                        }
+
+                        // 공동 경비 잔액 차감 및 최신 수정일 갱신
+                        totalShared.updateTotalSharedAmount(current.subtract(used));
+                        totalShared.updateLatestModified(java.time.LocalDate.now());
+                        totalSharedRepository.save(totalShared);
+
+                        //공동 경비 사용 이력 추가
+                        sharedRepository.save(Shared.builder()
+                                .trip(trip)
+                                .amount(used.negate())
+                                .currency(info.currency())
+                                .paymentMethod(PaymentMethod.valueOf(info.paymentMethod().trim().toLowerCase()))
+                                .createdAt(java.time.LocalDate.now())
+                                .build());
+                    }
 
                     return Pay.builder()
                             .expenseId(expense.getId())

--- a/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
@@ -2,10 +2,12 @@ package com.snapsplit.backend.global.exception;
 
 import com.snapsplit.backend.global.response.ApiResponse;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -25,6 +27,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception ex) {
+        log.error("예상치 못한 오류 발생", ex);
         return ResponseEntity.status(500).body(
                 ApiResponse.fail(500, "알 수 없는 오류가 발생했습니다.")
         );

--- a/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.snapsplit.backend.global.exception;
+
+import com.snapsplit.backend.global.response.ApiResponse;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(
+                ApiResponse.fail(400, ex.getMessage())
+        );
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(404).body(
+                ApiResponse.fail(404, ex.getMessage())
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception ex) {
+        return ResponseEntity.status(500).body(
+                ApiResponse.fail(500, "알 수 없는 오류가 발생했습니다.")
+        );
+    }
+}


### PR DESCRIPTION
### ✨ 개요
- 공동 경비 잔액으로 지출 추가하는 경우에 대한 로직 구현
- 공동 경비 잔액보다 큰 지출을 추가하려는 경우 에러 처리

### ✅ 세부 내용
- 기존 expenseDay기반으로 구현한 지출 추가에서 expenseDate기반으로 수정
- 지출 추가 요청시 공동경비 잔액보다 큰 금액을 지출금액으로 추가했을시 에러 처리 추가
- 지출 추가시 공동 경비 사용 내역 & 공동 경비 잔액에 반영되는 로직 추가
- 기존 로직 중 에러 해결
   - split 총합 == 공동경비를 제외한 사용자 payer들의 합계가 되도록 수정
- DTO 수정
   - tirpMemberId -> memberId
   - 추후 다른 tripMemberId도 memberId로 수정하여 통일할 예정 

### 🔐 관련 API
- POST /trips/{tripId}/expense

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 전역 예외 처리 기능이 추가되어, 잘못된 요청, 데이터 미존재, 알 수 없는 오류 발생 시 사용자에게 명확한 오류 메시지와 적절한 상태 코드가 제공됩니다.

* **버그 수정**
  * 비용 분할 시, 분할 금액의 합이 사용자 실제 결제 금액과 일치하는지 검증 로직이 개선되었습니다.
  * 공유 자금 사용 시 잔액 확인 및 차감 처리 로직이 추가되어 정확한 비용 처리와 기록이 가능해졌습니다.

* **리팩터**
  * 일부 필드명이 더 명확하게 변경되었습니다. (예: tripMemberId → memberId)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->