### PR TITLE
[Feat] 지출 추가하기

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
@@ -47,5 +47,7 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
 """)
     List<Trip> findOngoingTripsByUserId(@Param("userId") Long userId, @Param("today") LocalDate today);
 
+    List<TripMember> findAllByTripId(Long tripId);
+    
     boolean existsByTripAndUser(Trip trip, User user); // 이미 여행에 참여한 사용자인지 확인
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpensePageController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpensePageController.java
@@ -1,0 +1,36 @@
+package com.snapsplit.backend.feature.addExpense.controller;
+
+import com.snapsplit.backend.feature.addExpense.dto.AddExpensePageResponse;
+import com.snapsplit.backend.feature.addExpense.service.AddExpensePageService;
+import com.snapsplit.backend.global.aop.CheckTripMember;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+import java.time.LocalDate;
+
+
+@RestController
+@RequestMapping("/trips/{tripId}/expense")
+@RequiredArgsConstructor
+public class AddExpensePageController {
+
+    private final AddExpensePageService addExpensePageService;
+    @CheckTripMember
+    @Operation(
+            summary = "지출 추가 페이지 데이터 조회",
+            description = "지출 추가를 위한 초기 데이터를 불러옵니다. 해당 여행(tripId)과 날짜(date)에 따라 통화, 환율, 멤버 정보 등을 포함합니다."
+    )
+    @GetMapping("/new")
+    public ApiResponse<AddExpensePageResponse> getAddExpensePageData(
+            @PathVariable Long tripId,
+            @RequestParam(name = "date")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate date
+    ){
+
+        AddExpensePageResponse response = addExpensePageService.getAddExpensePageData(tripId, date);
+        return ApiResponse.success("지출 추가용 초기 데이터를 불러왔습니다.", response);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpensePageResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpensePageResponse.java
@@ -1,0 +1,24 @@
+package com.snapsplit.backend.feature.addExpense.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record AddExpensePageResponse(
+        String defaultCurrency,
+        List<String> availCurrencies,
+        Map<String, BigDecimal> exchangeRates,
+        String defaultDate,
+        List<MemberDto> members
+) {
+
+    @Builder
+    public record MemberDto(
+            Long memberId,
+            String name,
+            String memberType // USER | SHARED_FUND
+    ) {}
+}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
@@ -1,0 +1,68 @@
+package com.snapsplit.backend.feature.addExpense.service;
+
+import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
+import com.snapsplit.backend.domain.totalshared.repository.TotalSharedRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository;
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
+import com.snapsplit.backend.feature.addExpense.dto.AddExpensePageResponse;
+import com.snapsplit.backend.feature.getExchangeRate.service.ExchangeRateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AddExpensePageService {
+
+    private final TripRepository tripRepository;
+    private final TripMemberRepository tripMemberRepository;
+    private final TripCountryRepository tripCountryRepository;
+    private final ExchangeRateService exchangeRateService;
+
+    public AddExpensePageResponse getAddExpensePageData(Long tripId, LocalDate date) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
+
+        // 1. 대표 통화
+        String defaultCurrency = trip.getDefaultCurrency();
+
+        // 2. 사용 가능한 통화 (여행 국가의 통화 + 무조건 KRW 포함)
+        Set<String> currencySet = tripCountryRepository.findAllByTripId(trip.getId()).stream()
+                .map(tc -> tc.getCountry().getCurrency())
+                .collect(Collectors.toSet());
+        currencySet.add("KRW"); // 항상 포함
+        List<String> availCurrencies = new ArrayList<>(currencySet);
+
+        // 3. 환율 정보 조회 (모든 통화에 대해)
+        Map<String, BigDecimal> exchangeRates = new HashMap<>();
+        for (String cur : availCurrencies) {
+            var rateResponse = exchangeRateService.fetchExchangeRate(cur);
+            exchangeRates.put(cur, BigDecimal.valueOf(rateResponse.getRateToKrw()));
+        }
+
+        // 4. 여행 멤버 목록
+        List<AddExpensePageResponse.MemberDto> members = tripMemberRepository.findAllByTripId(trip.getId()).stream()
+                .map(tm -> AddExpensePageResponse.MemberDto.builder()
+                        .memberId(tm.getId())
+                        .name(tm.getUser() != null ? tm.getUser().getName() : "공동경비")
+                        .memberType(tm.getUser() == null ? "SHARED_FUND" : "USER")
+                        .build())
+                .toList();
+
+        // 5. 최종 응답 구성
+        return AddExpensePageResponse.builder()
+                .defaultCurrency(defaultCurrency)
+                .availCurrencies(availCurrencies)
+                .exchangeRates(exchangeRates)
+                .members(members)
+                .defaultDate(date.toString())
+                .build();
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -131,6 +131,7 @@ public class AddExpenseService {
                         sharedRepository.save(Shared.builder()
                                 .trip(trip)
                                 .amount(used.negate())
+                                .amountKRW(used.negate().multiply(rate))
                                 .currency(info.currency())
                                 .paymentMethod(parsePaymentMethod(info.paymentMethod()))
                                 .createdAt(java.time.LocalDate.now())

--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/dto/ExchangeRateResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/dto/ExchangeRateResponse.java
@@ -2,8 +2,9 @@ package com.snapsplit.backend.feature.getExchangeRate.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @Builder
 public class ExchangeRateResponse {
     private String base; // 국가


### PR DESCRIPTION
### ✨ 개요
- 지출 추가하기 페이지 초기 데이터 불러오기 구현
- 지출 추가하기 POST 세부 기능 수정

### ✅ 작업 내용
- 지출 추가하기 페이지
  - 대표통화, 모든통화리스트, 멤버정보, 환율정보를 포함하여 초기데이터를 보여줌
  - 특정 여행일에 속한 지출 추가버튼을 누르면 그 날짜를 파라미터로 포함

### 📌 향후 추가 사항
- 정산 영수증 뽑은 날짜에 대한 정보 같이 보내줘야 함
- 영수증으로 지출 등록 기능 추가

### 🔐 관련 API
- GET /trips/{tripId}/expense/new?date={}
- POST /trips/{tripId}/expense

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여행 경비 추가 페이지를 위한 API가 추가되어, 기본 통화, 사용 가능한 통화 목록, 환율, 기본 날짜, 멤버 정보 등을 조회할 수 있습니다.

* **버그 수정**
  * 공동 경비 사용 내역 저장 시 원화 기준 금액(`amountKRW`)이 정확히 반영되도록 개선되었습니다.

* **기타**
  * 환율 응답 객체의 접근 방식이 변경되어, 불필요한 setter 및 기타 메서드가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->