### PR TITLE
[Feat] 여행 홈 - 지출 상세보기

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
@@ -6,7 +6,12 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface PayRepository extends JpaRepository<Pay, Long> {
+
+    @Query("SELECT p FROM Pay p WHERE p.expenseId = :expenseId")
+    List<Pay> findByExpenseId(@Param("expenseId") Long expenseId);
 
     @Modifying
     @Query("DELETE FROM Pay p WHERE p.expenseId = :expenseId")

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
@@ -5,8 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import java.util.List;
 
 public interface SplitRepository extends JpaRepository<Split, Long> {
+
+    @Query("SELECT s FROM Split s WHERE s.expenseId = :expenseId")
+    List<Split> findByExpenseId(@Param("expenseId") Long expenseId);
+
     @Modifying
     @Query("DELETE FROM Split s WHERE s.expenseId = :expenseId")
     void deleteByExpenseId(@Param("expenseId") Long expenseId);

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
@@ -1,6 +1,7 @@
 package com.snapsplit.backend.feature.addExpense.controller;
 
 import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
+import com.snapsplit.backend.feature.addExpense.dto.ExpenseDetailResponse;
 import com.snapsplit.backend.feature.addExpense.service.AddExpenseService;
 import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
@@ -47,6 +48,23 @@ public class AddExpenseController {
                     ApiResponse.fail(404, e.getMessage())
             );
         }
+    }
+
+    //지출 상세 조회
+    @CheckTripMember
+    @GetMapping("/{expenseId}")
+    @Operation(
+            summary = "지출 상세 조회",
+            description = "특정 여행(tripId) 내 특정 지출(expenseId)의 상세 정보를 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<ExpenseDetailResponse>> getExpenseDetail(
+            @PathVariable Long tripId,
+            @PathVariable Long expenseId
+    ) {
+        ExpenseDetailResponse response = addExpenseService.getExpenseDetail(tripId, expenseId);
+        return ResponseEntity.ok(
+                ApiResponse.success("지출 상세 조회 성공", response)
+        );
     }
 
 

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpenseController.java
@@ -61,10 +61,20 @@ public class AddExpenseController {
             @PathVariable Long tripId,
             @PathVariable Long expenseId
     ) {
-        ExpenseDetailResponse response = addExpenseService.getExpenseDetail(tripId, expenseId);
-        return ResponseEntity.ok(
-                ApiResponse.success("지출 상세 조회 성공", response)
-        );
+        try{
+            ExpenseDetailResponse response = addExpenseService.getExpenseDetail(tripId, expenseId);
+            return ResponseEntity.ok(
+                    ApiResponse.success("지출 상세 조회 성공", response)
+            );
+        } catch(IllegalArgumentException e){
+            return ResponseEntity.badRequest().body(
+                    ApiResponse.fail(400, e.getMessage())
+            );
+        } catch(EntityNotFoundException e){
+            return ResponseEntity.status(404).body(
+                    ApiResponse.fail(404, e.getMessage())
+            );
+        }
     }
 
 

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpensePageController.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/controller/AddExpensePageController.java
@@ -27,7 +27,7 @@ public class AddExpensePageController {
     public ApiResponse<AddExpensePageResponse> getAddExpensePageData(
             @PathVariable Long tripId,
             @RequestParam(name = "date")
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate date
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ){
 
         AddExpensePageResponse response = addExpensePageService.getAddExpensePageData(tripId, date);

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/ExpenseDetailResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/ExpenseDetailResponse.java
@@ -3,6 +3,8 @@ package com.snapsplit.backend.feature.addExpense.dto;
 import lombok.Builder;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Currency;
 import java.util.List;
 
 @Builder
@@ -12,7 +14,7 @@ public record ExpenseDetailResponse(
         BigDecimal amountKRW,
         String currency,
         String paymentMethod,
-        String date,
+        LocalDate date,
         String expenseName,
         String expenseMemo,
         String category,

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/ExpenseDetailResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/ExpenseDetailResponse.java
@@ -1,0 +1,28 @@
+package com.snapsplit.backend.feature.addExpense.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+public record ExpenseDetailResponse(
+        Long expenseId,
+        BigDecimal amount,
+        BigDecimal amountKRW,
+        String currency,
+        String paymentMethod,
+        String date,
+        String expenseName,
+        String expenseMemo,
+        String category,
+        List<MemberAmountDto> payers,
+        List<MemberAmountDto> splitters
+) {
+    @Builder
+    public record MemberAmountDto(
+            Long memberId,
+            String name,
+            BigDecimal amount
+    ) {}
+}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -11,6 +11,7 @@ import com.snapsplit.backend.domain.trip.repository.TripRepository;
 import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
+import com.snapsplit.backend.feature.addExpense.dto.ExpenseDetailResponse;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -162,6 +163,56 @@ public class AddExpenseService {
         return expense.getId();
     }
 
+
+    //지출 상세보기
+    @Transactional(readOnly = true)
+    public ExpenseDetailResponse getExpenseDetail(Long tripId, Long expenseId) {
+        Expense expense = expenseRepository.findById(expenseId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 지출이 존재하지 않습니다."));
+
+        if (!expense.getTripId().equals(tripId)) {
+            throw new IllegalArgumentException("해당 여행의 지출이 아닙니다.");
+        }
+
+        List<ExpenseDetailResponse.MemberAmountDto> payers = payRepository.findByExpenseId(expenseId)
+                .stream()
+                .map(pay -> {
+                    TripMember member = tripMemberRepository.findById(pay.getPayerId())
+                            .orElseThrow(() -> new EntityNotFoundException("해당 결제자 멤버를 찾을 수 없습니다."));
+                    String name = (member.getUser() != null) ? member.getUser().getName() : "공동경비";
+                    return ExpenseDetailResponse.MemberAmountDto.builder()
+                            .memberId(member.getId())
+                            .name(name)
+                            .amount(pay.getPayAmount())
+                            .build();
+                }).toList();
+
+        List<ExpenseDetailResponse.MemberAmountDto> splitters = splitRepository.findByExpenseId(expenseId)
+                .stream()
+                .map(split -> {
+                    TripMember member = tripMemberRepository.findById(split.getSplitterId())
+                            .orElseThrow(() -> new EntityNotFoundException("해당 분담자 멤버를 찾을 수 없습니다."));
+                    return ExpenseDetailResponse.MemberAmountDto.builder()
+                            .memberId(member.getId())
+                            .name(member.getUser().getName())
+                            .amount(split.getSplitAmount())
+                            .build();
+                }).toList();
+
+        return ExpenseDetailResponse.builder()
+                .expenseId(expense.getId())
+                .amount(expense.getExpenseAmount())
+                .amountKRW(expense.getExpenseKrw())
+                .currency(expense.getExpenseCurrency())
+                .paymentMethod(expense.getPaymentMethod().toString().toLowerCase())
+                .date(expense.getExpenseDate().toString())
+                .expenseName(expense.getExpenseName())
+                .expenseMemo(expense.getExpenseMemo())
+                .category(expense.getCategory().toString())
+                .payers(payers)
+                .splitters(splitters)
+                .build();
+    }
 
     //지출 삭제
     @Transactional

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.Currency;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -205,7 +206,7 @@ public class AddExpenseService {
                 .amountKRW(expense.getExpenseKrw())
                 .currency(expense.getExpenseCurrency())
                 .paymentMethod(expense.getPaymentMethod().toString().toLowerCase())
-                .date(expense.getExpenseDate().toString())
+                .date(expense.getExpenseDate())
                 .expenseName(expense.getExpenseName())
                 .expenseMemo(expense.getExpenseMemo())
                 .category(expense.getCategory().toString())


### PR DESCRIPTION
### ✨ 개요
여행 홈 - 지출 상세보기 페이지

### ✅ 작업 내용
- 등록한 지출에 대한 내역을 확인할 수 있음
- 상세보기 페이지에서 지출 수정/삭제가 가능함
  - 수정/삭제는 이미 구현돼있음
  
 ### 🔐 관련 API
- GET /trips/{tripId}/expense/{expenseId}
- PUT /trips/{tripId}/expense/{expenseId}
- DELETE /trips/{tripId}/expense/{expenseId}

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 여행 내 특정 지출 내역의 상세 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.
  * 지출 상세 정보에는 금액, 통화, 결제수단, 날짜, 이름, 메모, 카테고리, 지불자 및 분배자 목록이 포함됩니다.

* **기능 개선**
  * 지출 추가 페이지의 날짜 입력 형식이 '날짜-시간'에서 '날짜' 형식으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->