### PR TITLE
[Feat] Shared 테이블 sharedType, expenseId추가 및 관련 지출 추가/수정/삭제 로직 변경

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/shared/entity/Shared.java
+++ b/src/main/java/com/snapsplit/backend/domain/shared/entity/Shared.java
@@ -40,4 +40,10 @@ public class Shared {
     @Column(name = "payment_method", nullable = false)
     private PaymentMethod paymentMethod; // 경비 입금 방식
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "shared_type", nullable = false)
+    private SharedType sharedType; // 사용 유형 (입금/출금/지출)
+
+    @Column(name = "expense_id")
+    private Long expenseId; // 지출에 의해 차감된 경우 연관된 지출 ID (nullable)
 }

--- a/src/main/java/com/snapsplit/backend/domain/shared/entity/SharedType.java
+++ b/src/main/java/com/snapsplit/backend/domain/shared/entity/SharedType.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.shared.entity;
+
+public enum SharedType {
+    DEPOSIT,
+    WITHDRAW,
+    EXPENSE
+}

--- a/src/main/java/com/snapsplit/backend/domain/shared/repository/SharedRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/shared/repository/SharedRepository.java
@@ -1,11 +1,23 @@
 package com.snapsplit.backend.domain.shared.repository;
 
 import com.snapsplit.backend.domain.shared.entity.Shared;
+import com.snapsplit.backend.domain.shared.entity.SharedType;
 import com.snapsplit.backend.domain.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface SharedRepository extends JpaRepository<Shared, Long> {
+
+    @Modifying
+    @Query("DELETE FROM Shared s WHERE s.trip.id = :tripId AND s.expenseId = :expenseId AND s.sharedType = :sharedType")
+    void deleteByTripIdAndExpenseIdAndSharedType(
+            @Param("tripId") Long tripId,
+            @Param("expenseId") Long expenseId,
+            @Param("sharedType") SharedType sharedType
+    );
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -12,13 +12,13 @@ import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
 import com.snapsplit.backend.feature.addExpense.dto.ExpenseDetailResponse;
+import com.snapsplit.backend.domain.shared.entity.SharedType;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.util.Currency;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -137,6 +137,8 @@ public class AddExpenseService {
                                 .currency(info.currency())
                                 .paymentMethod(parsePaymentMethod(info.paymentMethod()))
                                 .createdAt(java.time.LocalDate.now())
+                                .sharedType(SharedType.EXPENSE)
+                                .expenseId(expense.getId())
                                 .build());
                     }
 
@@ -226,9 +228,31 @@ public class AddExpenseService {
             throw new IllegalArgumentException("여행 정보가 일치하지 않습니다.");
         }
 
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("여행 정보가 존재하지 않습니다."));
+
+        // 공동경비로 지불한 금액 복원
+        List<Pay> pays = payRepository.findByExpenseId(expenseId);
+        for (Pay pay : pays) {
+            if (pay.getMemberType() == Pay.MemberType.SHARED_FUND) {
+                var totalShared = totalSharedRepository.findByTripAndTotalSharedCurrency(trip, expense.getExpenseCurrency())
+                        .orElseThrow(() -> new IllegalArgumentException("해당 통화의 공동경비가 존재하지 않습니다."));
+
+                totalShared.updateTotalSharedAmount(totalShared.getTotalSharedAmount().add(pay.getPayAmount()));
+                totalShared.updateLatestModified(java.time.LocalDate.now());
+                totalSharedRepository.save(totalShared);
+            }
+        }
+
         payRepository.deleteByExpenseId(expenseId);
         splitRepository.deleteByExpenseId(expenseId);
         expenseRepository.deleteById(expenseId);
+
+        sharedRepository.deleteByTripIdAndExpenseIdAndSharedType(
+                tripId,
+                expenseId,
+                SharedType.EXPENSE
+        );
     }
 
 


### PR DESCRIPTION
### ✨ 개요
Shared 테이블 수정 및 관련 지출추가 기능 수정

### ✅ 세부 내용
- Shared 테이블 수정
  - sharedType, expenseId 칼럼 추가
  - sharedType은 enum으로 EXPENSE, DEPOSIT, WITHDRAW로 구분함
  - 지출 수정시 관련 shared데이터도 expenseId로 접근하여 수정하기 위함
- 지출 추가시 sharedType은 EXPENSE로 지정하여 Shared에 추가됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 공유 내역에 거래 유형(입금, 출금, 지출)과 관련된 지출 ID를 구분하는 기능이 추가되었습니다.
  * 공유 내역에서 특정 여행, 지출, 거래 유형에 따라 기록을 삭제할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 지출 삭제 시 공유 자금 잔액이 올바르게 복원되고, 관련 공유 기록이 정확히 삭제되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->