### PR TITLE
[Feat] 여행 홈 - 지출 상세 바텀시트 

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/expense/entity/CategoryExpense.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/entity/CategoryExpense.java
@@ -34,9 +34,8 @@ public class CategoryExpense {
     @Column(name = "amount_krw", nullable = false)
     private BigDecimal amountKRW;
 
-    @Builder.Default
     @Column(name = "updated_at")
-    private LocalDateTime updatedAt = LocalDateTime.now();
+    private LocalDateTime updatedAt;
 
     public void increase(BigDecimal amount) {
         this.amountKRW = this.amountKRW.add(amount);

--- a/src/main/java/com/snapsplit/backend/domain/expense/entity/CategoryExpense.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/entity/CategoryExpense.java
@@ -1,0 +1,61 @@
+package com.snapsplit.backend.domain.expense.entity;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "category_expense",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"trip_id", "category"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CategoryExpense {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_expense_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 30)
+    private Expense.Category category;  // 💡 여기만 이렇게 수정
+
+    @Column(name = "amount_krw", nullable = false)
+    private BigDecimal amountKRW;
+
+    @Builder.Default
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    public void increase(BigDecimal amount) {
+        this.amountKRW = this.amountKRW.add(amount);
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void decrease(BigDecimal amount) {
+        this.amountKRW = this.amountKRW.subtract(amount);
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    public void onCreate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/CategoryExpenseRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/CategoryExpenseRepository.java
@@ -1,0 +1,15 @@
+package com.snapsplit.backend.domain.expense.repository;
+
+import com.snapsplit.backend.domain.expense.entity.CategoryExpense;
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CategoryExpenseRepository extends JpaRepository<CategoryExpense, Long> {
+    List<CategoryExpense> findByTrip(Trip trip);
+    Optional<CategoryExpense> findByTripAndCategory(Trip trip, Expense.Category category);
+
+}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -13,6 +13,7 @@ import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
 import com.snapsplit.backend.feature.addExpense.dto.ExpenseDetailResponse;
 import com.snapsplit.backend.domain.shared.entity.SharedType;
+import com.snapsplit.backend.feature.getCategoryExpense.service.CategoryExpenseService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,8 @@ public class AddExpenseService {
     private final SharedRepository sharedRepository;
     private final TotalSharedRepository totalSharedRepository;
     private final TripRepository tripRepository;
+    private final CategoryExpenseService categoryExpenseService;
+
 
 
     //지출 추가
@@ -163,6 +166,12 @@ public class AddExpenseService {
         ).toList();
         splitRepository.saveAll(splits);
 
+        //카테고리별 누적 지출 반영
+        categoryExpenseService.updateOnExpenseAdd(
+                tripId,
+                expense.getCategory(),
+                expense.getExpenseKrw()
+        );
         return expense.getId();
     }
 
@@ -252,6 +261,13 @@ public class AddExpenseService {
                 tripId,
                 expenseId,
                 SharedType.EXPENSE
+        );
+
+        // 카테고리별 누적 지출 차감
+        categoryExpenseService.updateOnExpenseDelete(
+                tripId,
+                expense.getCategory(),
+                expense.getExpenseKrw()
         );
     }
 

--- a/src/main/java/com/snapsplit/backend/feature/getCategoryExpense/controller/CategoryExpenseController.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCategoryExpense/controller/CategoryExpenseController.java
@@ -1,0 +1,23 @@
+package com.snapsplit.backend.feature.getCategoryExpense.controller;
+
+import com.snapsplit.backend.feature.getCategoryExpense.dto.CategoryExpenseResponse;
+import com.snapsplit.backend.feature.getCategoryExpense.service.CategoryExpenseService;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/trips/{tripId}/statistics")
+@RequiredArgsConstructor
+public class CategoryExpenseController {
+
+    private final CategoryExpenseService categoryExpenseService;
+
+    @GetMapping
+    @Operation(summary = "카테고리별 누적 지출 조회", description = "여행별로 7가지 카테고리 기준 누적 지출 금액(KRW)을 반환합니다.")
+    public ApiResponse<CategoryExpenseResponse> getCategoryStatistics(@PathVariable Long tripId) {
+        CategoryExpenseResponse response = categoryExpenseService.getCategoryStatistics(tripId);
+        return ApiResponse.success("카테고리별 누적 지출 조회 성공", response);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/getCategoryExpense/dto/CategoryExpenseResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCategoryExpense/dto/CategoryExpenseResponse.java
@@ -1,0 +1,19 @@
+package com.snapsplit.backend.feature.getCategoryExpense.dto;
+
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record CategoryExpenseResponse(
+        BigDecimal totalAmountKRW,
+        List<CategoryExpenseDto> categoryExpenses
+) {
+
+    @Builder
+    public record CategoryExpenseDto(
+            Expense.Category category,
+            BigDecimal amountKRW
+    ) {}
+}

--- a/src/main/java/com/snapsplit/backend/feature/getCategoryExpense/service/CategoryExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCategoryExpense/service/CategoryExpenseService.java
@@ -50,21 +50,23 @@ public class CategoryExpenseService {
     //지출 추가시 카테고리별 누적 지출 금액 증가
     @Transactional
     public void updateOnExpenseAdd(Long tripId, Expense.Category category, BigDecimal amountKRW) {
+        if (amountKRW == null || amountKRW.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("금액은 0 이상이어야 합니다.");
+        }
+
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
 
         CategoryExpense categoryExpense = categoryExpenseRepository.findByTripAndCategory(trip, category)
-                .orElse(null);
-
-        if (categoryExpense == null) {
-            categoryExpense = CategoryExpense.builder()
-                    .trip(trip)
-                    .category(category)
-                    .amountKRW(amountKRW)
-                    .build();
-        } else {
-            categoryExpense.increase(amountKRW);
-        }
+                .map(existing -> {
+                    existing.increase(amountKRW);
+                    return existing;
+                })
+                .orElseGet(() -> CategoryExpense.builder()
+                        .trip(trip)
+                        .category(category)
+                        .amountKRW(amountKRW)
+                        .build());
 
         categoryExpenseRepository.save(categoryExpense);
     }
@@ -72,15 +74,19 @@ public class CategoryExpenseService {
     // 지출 삭제시 카테고리별 누적 지출 금액 차감
     @Transactional
     public void updateOnExpenseDelete(Long tripId, Expense.Category category, BigDecimal amountKRW) {
+        if (amountKRW == null || amountKRW.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("금액은 0 이상이어야 합니다.");
+        }
+
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
 
         CategoryExpense categoryExpense = categoryExpenseRepository.findByTripAndCategory(trip, category)
-                .orElse(null);
-
-        if (categoryExpense != null) {
-            categoryExpense.decrease(amountKRW);
-            categoryExpenseRepository.save(categoryExpense);
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리의 지출 기록이 존재하지 않습니다."));
+        if (categoryExpense.getAmountKRW().compareTo(amountKRW) < 0) {
+            throw new IllegalArgumentException("차감할 금액이 현재 누적 금액보다 큽니다.");
         }
+        categoryExpense.decrease(amountKRW);
+        categoryExpenseRepository.save(categoryExpense);
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/getCategoryExpense/service/CategoryExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getCategoryExpense/service/CategoryExpenseService.java
@@ -1,0 +1,86 @@
+package com.snapsplit.backend.feature.getCategoryExpense.service;
+
+import com.snapsplit.backend.domain.expense.entity.CategoryExpense;
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import com.snapsplit.backend.domain.expense.repository.CategoryExpenseRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.feature.getCategoryExpense.dto.CategoryExpenseResponse;
+import com.snapsplit.backend.feature.getCategoryExpense.dto.CategoryExpenseResponse.CategoryExpenseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryExpenseService {
+
+    private final TripRepository tripRepository;
+    private final CategoryExpenseRepository categoryExpenseRepository;
+
+    @Transactional(readOnly = true)
+    public CategoryExpenseResponse getCategoryStatistics(Long tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
+
+        List<CategoryExpense> categoryExpenses = categoryExpenseRepository.findByTrip(trip);
+
+        Map<Expense.Category, BigDecimal> amountMap = categoryExpenses.stream()
+                .collect(Collectors.toMap(
+                        CategoryExpense::getCategory,
+                        CategoryExpense::getAmountKRW
+                ));
+
+        List<CategoryExpenseDto> categoryExpenseDtos = Arrays.stream(Expense.Category.values())
+                .map(cat -> new CategoryExpenseDto(cat, amountMap.getOrDefault(cat, BigDecimal.ZERO)))
+                .toList();
+
+        BigDecimal total = categoryExpenseDtos.stream()
+                .map(CategoryExpenseDto::amountKRW)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return new CategoryExpenseResponse(total, categoryExpenseDtos);
+    }
+
+
+    //지출 추가시 카테고리별 누적 지출 금액 증가
+    @Transactional
+    public void updateOnExpenseAdd(Long tripId, Expense.Category category, BigDecimal amountKRW) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
+
+        CategoryExpense categoryExpense = categoryExpenseRepository.findByTripAndCategory(trip, category)
+                .orElse(null);
+
+        if (categoryExpense == null) {
+            categoryExpense = CategoryExpense.builder()
+                    .trip(trip)
+                    .category(category)
+                    .amountKRW(amountKRW)
+                    .build();
+        } else {
+            categoryExpense.increase(amountKRW);
+        }
+
+        categoryExpenseRepository.save(categoryExpense);
+    }
+
+    // 지출 삭제시 카테고리별 누적 지출 금액 차감
+    @Transactional
+    public void updateOnExpenseDelete(Long tripId, Expense.Category category, BigDecimal amountKRW) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
+
+        CategoryExpense categoryExpense = categoryExpenseRepository.findByTripAndCategory(trip, category)
+                .orElse(null);
+
+        if (categoryExpense != null) {
+            categoryExpense.decrease(amountKRW);
+            categoryExpenseRepository.save(categoryExpense);
+        }
+    }
+}


### PR DESCRIPTION
### ✨ 개요
여행 홈 하단에서 접근할 수 있는 지출 상세 바텀시트 구현

### ✅ 세부 내용
- 7가지 카테고리별 누적 지출 정보 불러오기
- 지출 추가/수정/삭제시 바로 해당 카테고리에 해당하는 누적합을 수정함
- 아직 특정 카테고리에 해당하는 지출이 없다면 response에 0원을 넣어서 항상 7가지 카테고리 정보를 모두 보내도록함

### 🔐 관련 API
- GET /trips/{tripId}/statistics

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영됨
- 현재는 해당 여행의 모든 지출합을 계산하고있음
- 추구해 사용자별 누적 지출을 보고싶다면 수정가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 여행별 카테고리별 지출 통계 확인이 가능한 REST API가 추가되었습니다.
  * 카테고리별 누적 지출 금액이 자동으로 집계 및 관리됩니다.
  * 각 카테고리별 및 전체 지출 금액을 한눈에 확인할 수 있는 응답 구조가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->