### PR TITLE
[Feat] 공동경비 추가 및 빼기 - sharedType 지정 로직 추가

### DIFF
--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/AddTotalSharedService.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/AddTotalSharedService.java
@@ -1,6 +1,7 @@
 package com.snapsplit.backend.feature.updateTotalShared.service;
 
 import com.snapsplit.backend.domain.shared.entity.Shared;
+import com.snapsplit.backend.domain.shared.entity.SharedType;
 import com.snapsplit.backend.domain.shared.repository.SharedRepository;
 import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
 import com.snapsplit.backend.domain.totalshared.repository.TotalSharedRepository;
@@ -40,6 +41,7 @@ public class AddTotalSharedService {
                 .amountKRW(amountKRW)
                 .currency(request.getCurrency())
                 .paymentMethod(request.getPaymentMethod())
+                .sharedType(SharedType.DEPOSIT)
                 .createdAt(request.getCreatedAt())
                 .build();
         sharedRepository.save(shared);

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/RemoveTotalSharedService.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/RemoveTotalSharedService.java
@@ -51,7 +51,7 @@ public class RemoveTotalSharedService {
                 .amountKRW(amountKRW)
                 .currency(request.getCurrency())
                 .paymentMethod(request.getPaymentMethod())
-                .sharedType(SharedType.DEPOSIT)
+                .sharedType(SharedType.WITHDRAW)
                 .createdAt(request.getCreatedAt())
                 .build();
         sharedRepository.save(shared);

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/RemoveTotalSharedService.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/RemoveTotalSharedService.java
@@ -1,6 +1,7 @@
 package com.snapsplit.backend.feature.updateTotalShared.service;
 
 import com.snapsplit.backend.domain.shared.entity.Shared;
+import com.snapsplit.backend.domain.shared.entity.SharedType;
 import com.snapsplit.backend.domain.shared.repository.SharedRepository;
 import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
 import com.snapsplit.backend.domain.totalshared.repository.TotalSharedRepository;
@@ -50,6 +51,7 @@ public class RemoveTotalSharedService {
                 .amountKRW(amountKRW)
                 .currency(request.getCurrency())
                 .paymentMethod(request.getPaymentMethod())
+                .sharedType(SharedType.DEPOSIT)
                 .createdAt(request.getCreatedAt())
                 .build();
         sharedRepository.save(shared);


### PR DESCRIPTION
### ✨ 개요
공동경비 추가 및 빼기 기능에서 sharedType 지정해서 추가해주도록 수정

### ✅ 세부 내용
- 추가 시 `DEPOSIT`, 빼기 시 `WITHDRAW`로 sharedType 지정해서 추가하도록 수정

### 🔐 관련 API
- POST /trips/{tripId}/budget/add
- POST /trips/{tripId}/budget/remove


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 총 공유 금액 추가 시 공유 유형이 "DEPOSIT"으로 올바르게 설정되도록 수정되었습니다.
  * 총 공유 금액 제거 시 공유 유형이 "WITHDRAW"으로 올바르게 설정되도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->