### PR TITLE
[Feat] 여행 홈 불러오기

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/ExpenseRepository.java
@@ -3,5 +3,9 @@ package com.snapsplit.backend.domain.expense.repository;
 import com.snapsplit.backend.domain.expense.entity.Expense;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+    List<Expense> findAllByTripId(Long tripId);
+
 }

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
@@ -11,6 +11,7 @@ public interface SplitRepository extends JpaRepository<Split, Long> {
 
     @Query("SELECT s FROM Split s WHERE s.expenseId = :expenseId")
     List<Split> findByExpenseId(@Param("expenseId") Long expenseId);
+    List<Split> findByExpenseIdIn(List<Long> expenseIds);
 
     @Modifying
     @Query("DELETE FROM Split s WHERE s.expenseId = :expenseId")

--- a/src/main/java/com/snapsplit/backend/feature/tripHome/controller/TripHomeController.java
+++ b/src/main/java/com/snapsplit/backend/feature/tripHome/controller/TripHomeController.java
@@ -4,6 +4,7 @@ import com.snapsplit.backend.feature.tripHome.dto.TripHomeResponse;
 import com.snapsplit.backend.feature.tripHome.service.TripHomeService;
 import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,6 +15,10 @@ public class TripHomeController {
 
     private final TripHomeService tripHomeService;
 
+    @Operation(
+            summary = "여행 홈 정보 조회",
+            description = "여행 기본 정보, 공동 경비 잔액, 누적 지출 가장 큰 카테고리 정보, 날짜별 지출 내역, 총합을 포함한 홈 화면 데이터를 반환합니다."
+    )
     @GetMapping("/{tripId}/expenses")
     @CheckTripMember
     public ApiResponse<TripHomeResponse> getTripHome(@PathVariable Long tripId) {

--- a/src/main/java/com/snapsplit/backend/feature/tripHome/controller/TripHomeController.java
+++ b/src/main/java/com/snapsplit/backend/feature/tripHome/controller/TripHomeController.java
@@ -1,0 +1,23 @@
+package com.snapsplit.backend.feature.tripHome.controller;
+
+import com.snapsplit.backend.feature.tripHome.dto.TripHomeResponse;
+import com.snapsplit.backend.feature.tripHome.service.TripHomeService;
+import com.snapsplit.backend.global.aop.CheckTripMember;
+import com.snapsplit.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/trips")
+@RequiredArgsConstructor
+public class TripHomeController {
+
+    private final TripHomeService tripHomeService;
+
+    @GetMapping("/{tripId}/expenses")
+    @CheckTripMember
+    public ApiResponse<TripHomeResponse> getTripHome(@PathVariable Long tripId) {
+        TripHomeResponse response = tripHomeService.getTripHome(tripId);
+        return ApiResponse.success("여행 상세 조회 성공", response);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/tripHome/controller/TripHomeController.java
+++ b/src/main/java/com/snapsplit/backend/feature/tripHome/controller/TripHomeController.java
@@ -5,6 +5,8 @@ import com.snapsplit.backend.feature.tripHome.service.TripHomeService;
 import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,6 +20,7 @@ public class TripHomeController {
     @Operation(
             summary = "여행 홈 정보 조회",
             description = "여행 기본 정보, 공동 경비 잔액, 누적 지출 가장 큰 카테고리 정보, 날짜별 지출 내역, 총합을 포함한 홈 화면 데이터를 반환합니다."
+                    + " 참고: date 쿼리 파라미터(?date=YYYY-MM-DD)는 프론트엔드 스크롤 위치 조정용으로만 사용되며, 백엔드에서는 무시됩니다."
     )
     @GetMapping("/{tripId}/expenses")
     @CheckTripMember

--- a/src/main/java/com/snapsplit/backend/feature/tripHome/dto/TripHomeResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/tripHome/dto/TripHomeResponse.java
@@ -1,0 +1,50 @@
+package com.snapsplit.backend.feature.tripHome.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record TripHomeResponse(
+        Long tripId,
+        String tripName,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> countries,
+        SharedFundDto sharedFund,
+        TopCategoryExpenseDto topCategoryExpense,
+        List<DailyExpenseDto> dailyExpenses,
+        BigDecimal totalExpense
+) {
+
+    @Builder
+    public record SharedFundDto(
+            String defaultCurrency,
+            BigDecimal balance
+    ) {}
+
+    @Builder
+    public record TopCategoryExpenseDto(
+            String category,
+            BigDecimal amountKRW
+    ) {}
+
+    @Builder
+    public record DailyExpenseDto(
+            LocalDate date,
+            List<ExpenseDto> expenses
+    ) {}
+
+    @Builder
+    public record ExpenseDto(
+            Long expenseId,
+            String category,
+            String expenseName,
+            String expenseMemo,
+            BigDecimal amount,
+            String currency,
+            List<String> splitters // 이름만 담김
+    ) {}
+}

--- a/src/main/java/com/snapsplit/backend/feature/tripHome/service/TripHomeService.java
+++ b/src/main/java/com/snapsplit/backend/feature/tripHome/service/TripHomeService.java
@@ -17,6 +17,7 @@ import com.snapsplit.backend.feature.tripHome.dto.TripHomeResponse.*;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -35,6 +36,7 @@ public class TripHomeService {
     private final TripMemberRepository tripMemberRepository;
 
 
+    @Transactional(readOnly=true)
     public TripHomeResponse getTripHome(Long tripId) {
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
@@ -71,11 +73,9 @@ public class TripHomeService {
         // 전체 지출
         List<Expense> expenses = expenseRepository.findAllByTripId(tripId);
 
-        // 지출 ID로 모든 split 미리 조회
+        // 지출 ID로 모든 split 한 번에  조회
         List<Long> expenseIds = expenses.stream().map(Expense::getId).toList();
-        List<Split> allSplits = expenseIds.stream()
-                .flatMap(id -> splitRepository.findByExpenseId(id).stream())
-                .toList();
+        List<Split> allSplits = splitRepository.findByExpenseIdIn(expenseIds);
 
         // splitterId -> name Map 만들기
         Set<Long> splitterIds = allSplits.stream()
@@ -97,11 +97,16 @@ public class TripHomeService {
                 .sorted(Map.Entry.comparingByKey())
                 .map(entry -> {
                     LocalDate date = entry.getKey();
+                    // expense ID별로 splits를 그룹화
+                    Map<Long, List<Split>> splitsByExpenseId = allSplits.stream()
+                            .collect(Collectors.groupingBy(Split::getExpenseId));
+
                     List<ExpenseDto> expenseDtos = entry.getValue().stream()
                             .map(expense -> {
-                                List<String> splitterNames = allSplits.stream()
-                                        .filter(split -> Objects.equals(split.getExpenseId(), expense.getId()))
+                                List<String> splitterNames = splitsByExpenseId.getOrDefault(expense.getId(), Collections.emptyList())
+                                        .stream()
                                         .map(split -> splitterNameMap.get(split.getSplitterId()))
+                                        .filter(Objects::nonNull)
                                         .toList();
 
                                 return ExpenseDto.builder()

--- a/src/main/java/com/snapsplit/backend/feature/tripHome/service/TripHomeService.java
+++ b/src/main/java/com/snapsplit/backend/feature/tripHome/service/TripHomeService.java
@@ -1,0 +1,143 @@
+package com.snapsplit.backend.feature.tripHome.service;
+
+import com.snapsplit.backend.domain.expense.entity.CategoryExpense;
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import com.snapsplit.backend.domain.expense.entity.Split;
+import com.snapsplit.backend.domain.expense.repository.CategoryExpenseRepository;
+import com.snapsplit.backend.domain.expense.repository.ExpenseRepository;
+import com.snapsplit.backend.domain.expense.repository.SplitRepository;
+import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
+import com.snapsplit.backend.domain.totalshared.repository.TotalSharedRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
+import com.snapsplit.backend.feature.tripHome.dto.TripHomeResponse;
+import com.snapsplit.backend.feature.tripHome.dto.TripHomeResponse.*;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TripHomeService {
+
+    private final TripRepository tripRepository;
+    private final TotalSharedRepository totalSharedRepository;
+    private final CategoryExpenseRepository categoryExpenseRepository;
+    private final ExpenseRepository expenseRepository;
+    private final SplitRepository splitRepository;
+    private final TripMemberRepository tripMemberRepository;
+
+
+    public TripHomeResponse getTripHome(Long tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
+
+        // countries: TripCountry → Country → countryName
+        List<String> countries = trip.getTripCountries().stream()
+                .map(tripCountry -> tripCountry.getCountry().getCountryName())
+                .toList();
+
+        // 공동경비 정보 (대표통화 기준)
+        TotalShared totalShared = totalSharedRepository
+                .findByTripAndTotalSharedCurrency(trip, trip.getDefaultCurrency())
+                .orElse(null);
+
+        SharedFundDto sharedFund = SharedFundDto.builder()
+                .defaultCurrency(trip.getDefaultCurrency())
+                .balance(totalShared != null ? totalShared.getTotalSharedAmount() : BigDecimal.ZERO)
+                .build();
+
+        // 가장 큰 카테고리 지출
+        List<CategoryExpense> categoryExpenses = categoryExpenseRepository.findByTrip(trip);
+
+        CategoryExpense topCategory = categoryExpenses.stream()
+                .max(Comparator.comparing(CategoryExpense::getAmountKRW))
+                .orElse(null);
+
+        TopCategoryExpenseDto topCategoryExpense = topCategory != null ?
+                TopCategoryExpenseDto.builder()
+                        .category(topCategory.getCategory().name())
+                        .amountKRW(topCategory.getAmountKRW())
+                        .build()
+                : null;
+
+        // 전체 지출
+        List<Expense> expenses = expenseRepository.findAllByTripId(tripId);
+
+        // 지출 ID로 모든 split 미리 조회
+        List<Long> expenseIds = expenses.stream().map(Expense::getId).toList();
+        List<Split> allSplits = expenseIds.stream()
+                .flatMap(id -> splitRepository.findByExpenseId(id).stream())
+                .toList();
+
+        // splitterId -> name Map 만들기
+        Set<Long> splitterIds = allSplits.stream()
+                .map(Split::getSplitterId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> splitterNameMap = tripMemberRepository.findAllById(splitterIds).stream()
+                .collect(Collectors.toMap(
+                        TripMember::getId,
+                        tm -> tm.getUser().getName()
+                ));
+
+
+        // 날짜별 지출 그룹핑
+        Map<LocalDate, List<Expense>> expensesByDate = expenses.stream()
+                .collect(Collectors.groupingBy(Expense::getExpenseDate));
+
+        List<DailyExpenseDto> dailyExpenses = expensesByDate.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    LocalDate date = entry.getKey();
+                    List<ExpenseDto> expenseDtos = entry.getValue().stream()
+                            .map(expense -> {
+                                List<String> splitterNames = allSplits.stream()
+                                        .filter(split -> Objects.equals(split.getExpenseId(), expense.getId()))
+                                        .map(split -> splitterNameMap.get(split.getSplitterId()))
+                                        .toList();
+
+                                return ExpenseDto.builder()
+                                        .expenseId(expense.getId())
+                                        .category(expense.getCategory().name())
+                                        .expenseName(expense.getExpenseName())
+                                        .expenseMemo(expense.getExpenseMemo())
+                                        .amount(expense.getExpenseAmount())
+                                        .currency(expense.getExpenseCurrency())
+                                        .splitters(splitterNames)
+                                        .build();
+                            })
+                            .toList();
+
+                    return DailyExpenseDto.builder()
+                            .date(date)
+                            .expenses(expenseDtos)
+                            .build();
+                })
+                .toList();
+
+        // 전체 지출 총합 (KRW)
+        BigDecimal totalExpenseKRW = categoryExpenses.stream()
+                .map(CategoryExpense::getAmountKRW)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return TripHomeResponse.builder()
+                .tripId(trip.getId())
+                .tripName(trip.getTripName())
+                .startDate(trip.getStartDate())
+                .endDate(trip.getEndDate())
+                .countries(countries)
+                .sharedFund(sharedFund)
+                .topCategoryExpense(topCategoryExpense)
+                .dailyExpenses(dailyExpenses)
+                .totalExpense(totalExpenseKRW)
+                .build();
+    }
+}


### PR DESCRIPTION
### ✨ 개요
여행 홈 불러오기 구현

### ✅ 세부 내용
- 여행 정보 불러오기
- 공동 경비 잔액 불러오기
- 가장 지출이 많은 카테고리의 누적 지출 불러오기
- 전체 지출 리스트 불러오기
- 여행기간 총 누적 지출합 불러오기 (바텀시트)

### 🔐 관련 API
- GET /trips/{tripId}/expenses

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영됨
- 화면 중간 날짜 탭에서 특정 날짜를 선택하면 `?date=YYYY-MM-DD` 파라미터가 붙을 수 있으나, 이는 프론트에서 스크롤 위치 조절용
    - 백은 해당 파라미터를 사용하지 않고 전체 데이터를 응답


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 여행 홈 화면에서 여행 정보, 공유 자금 잔액, 최대 지출 카테고리, 일별 지출 내역 및 총합을 한 번에 조회할 수 있는 API가 추가되었습니다.  
  * 각 여행의 지출 내역을 일별로 확인할 수 있으며, 카테고리별 최대 지출 정보와 공유 자금 정보도 함께 제공합니다.  
  * 특정 여행 ID로 관련 지출 내역과 분할 정보를 효율적으로 조회할 수 있는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->