### PR TITLE
[Feat] 공동경비 추가 및 빼기 페이지

### DIFF
--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/controller/UpdateTotalSharedPageController.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/controller/UpdateTotalSharedPageController.java
@@ -1,0 +1,29 @@
+package com.snapsplit.backend.feature.updateTotalShared.controller;
+
+import com.snapsplit.backend.feature.updateTotalShared.dto.UpdateTotalSharedPageResponse;
+import com.snapsplit.backend.feature.updateTotalShared.service.UpdateTotalSharedPageService;
+
+import com.snapsplit.backend.global.aop.CheckTripMember;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trips/{tripId}/budget")
+public class UpdateTotalSharedPageController {
+
+    private final UpdateTotalSharedPageService updateTotalSharedPageService;
+
+    @Operation(summary = "공동경비 수정 페이지 로드", description = "공동경비 추가 및 삭제에서 필요한 정보를 제공합니다.")
+    @GetMapping
+    @CheckTripMember
+    public ResponseEntity<ApiResponse<UpdateTotalSharedPageResponse>> getUpdateTotalSharedPage(
+            @PathVariable Long tripId
+    ) {
+        UpdateTotalSharedPageResponse response = updateTotalSharedPageService.getPageData(tripId);
+        return ResponseEntity.ok(ApiResponse.success("공동경비 수정 페이지 로드 성공", response));
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/dto/UpdateTotalSharedPageResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/dto/UpdateTotalSharedPageResponse.java
@@ -1,0 +1,22 @@
+package com.snapsplit.backend.feature.updateTotalShared.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@Builder
+public class UpdateTotalSharedPageResponse {
+
+    private String defaultCurrency; // 대표 통화
+
+    private List<CurrencyRate> currencies; // 환율 리스트
+
+    @Data
+    @Builder
+    public static class CurrencyRate {
+        private String code; // 통화 코드
+        private BigDecimal exchangeRate; // 환율
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/UpdateTotalSharedPageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/UpdateTotalSharedPageService.java
@@ -1,0 +1,56 @@
+package com.snapsplit.backend.feature.updateTotalShared.service;
+
+import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository;
+import com.snapsplit.backend.feature.getExchangeRate.service.ExchangeRateService;
+import com.snapsplit.backend.feature.updateTotalShared.dto.UpdateTotalSharedPageResponse;
+import com.snapsplit.backend.feature.updateTotalShared.dto.UpdateTotalSharedPageResponse.CurrencyRate;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateTotalSharedPageService {
+
+    private final TripRepository tripRepository;
+    private final TripCountryRepository tripCountryRepository;
+    private final ExchangeRateService exchangeRateService;
+
+    public UpdateTotalSharedPageResponse getPageData(Long tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
+
+        // 대표 통화
+        String defaultCurrency = trip.getDefaultCurrency();
+
+        // 사용 가능한 통화 (여행 국가의 통화 + 무조건 KRW 포함)
+        Set<String> currencySet = tripCountryRepository.findAllByTripId(trip.getId()).stream()
+                .map(tc -> tc.getCountry().getCurrency())
+                .collect(Collectors.toSet());
+        currencySet.add("KRW"); // 항상 포함
+        List<String> availCurrencies = new ArrayList<>(currencySet);
+
+        // 환율 정보 조회 + CurrencyRate 객체로 변환
+        List<CurrencyRate> currencies = availCurrencies.stream()
+                .map(code -> {
+                    var rateResponse = exchangeRateService.fetchExchangeRate(code);
+                    return CurrencyRate.builder()
+                            .code(code)
+                            .exchangeRate(BigDecimal.valueOf(rateResponse.getRateToKrw()))
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        // 응답 반환
+        return UpdateTotalSharedPageResponse.builder()
+                .defaultCurrency(defaultCurrency)
+                .currencies(currencies)
+                .build();
+    }
+
+}


### PR DESCRIPTION
### ✨ 개요
공동경비 추가 또는 빼기 페이지에서 초기에 보여줘야 하는 정보를 전달

### ✅ 세부 내용
- 이용 가능한 통화 리스트에 대해 현재 환율 보여주기
- 현재 대표통화 응답에 포함

### 🔐 관련 API
- GET `/trips/{tripId}/budget`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여행의 예산 공유 페이지를 위한 정보를 조회하는 새로운 API 엔드포인트가 추가되었습니다. 이제 각 여행별로 기본 통화와 다양한 통화의 환율 정보를 확인할 수 있습니다. 해당 기능은 여행 멤버만 접근할 수 있도록 보안이 적용되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->