### PR TITLE
[Feat] 대표 통화 변경

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/repository/TripRepository.java
@@ -2,9 +2,16 @@ package com.snapsplit.backend.domain.trip.repository;
 
 import com.snapsplit.backend.domain.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
     Optional<Trip> findByTripCode(String tripCode); // TripCode로 Trip 찾기
+
+    @Modifying
+    @Query("UPDATE Trip t SET t.defaultCurrency = :defaultCurrency WHERE t.id = :tripId")
+    void updateDefaultCurrencyById(@Param("tripId") Long tripId, @Param("defaultCurrency") String defaultCurrency);
 }

--- a/src/main/java/com/snapsplit/backend/feature/getSharedDetails/controller/GetSharedDetailsController.java
+++ b/src/main/java/com/snapsplit/backend/feature/getSharedDetails/controller/GetSharedDetailsController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/trips/{tripId}/shared/details")
+@RequestMapping("/trips/{tripId}/budget/details")
 @RequiredArgsConstructor
 public class GetSharedDetailsController {
 

--- a/src/main/java/com/snapsplit/backend/feature/getSharedDetails/controller/UpdateDefaultCurrencyController.java
+++ b/src/main/java/com/snapsplit/backend/feature/getSharedDetails/controller/UpdateDefaultCurrencyController.java
@@ -1,0 +1,31 @@
+package com.snapsplit.backend.feature.getSharedDetails.controller;
+
+import com.snapsplit.backend.feature.getSharedDetails.dto.SharedDetailsResponse;
+import com.snapsplit.backend.feature.getSharedDetails.dto.UpdateDefaultCurrencyResponse;
+import com.snapsplit.backend.feature.getSharedDetails.service.UpdateDefaultCurrencyService;
+import com.snapsplit.backend.global.aop.CheckTripMember;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/trips/{tripId}/budget")
+@RequiredArgsConstructor
+public class UpdateDefaultCurrencyController {
+
+    private final UpdateDefaultCurrencyService updateDefaultCurrencyService;
+
+    @Operation(summary = "대표 통화 변경", description = "대표 통화를 변경합니다.")
+    @PatchMapping
+    @CheckTripMember
+    public ResponseEntity<ApiResponse<UpdateDefaultCurrencyResponse>> updateDefaultCurrency(
+            @PathVariable Long tripId,
+            @RequestParam String newDefaultCur
+    ) {
+        UpdateDefaultCurrencyResponse response = updateDefaultCurrencyService.updateDefaultCurrency(tripId, newDefaultCur);
+        return ResponseEntity.ok(ApiResponse.success("대표 통화 변경 성공", response));
+    }
+
+}

--- a/src/main/java/com/snapsplit/backend/feature/getSharedDetails/dto/UpdateDefaultCurrencyResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/getSharedDetails/dto/UpdateDefaultCurrencyResponse.java
@@ -1,0 +1,11 @@
+package com.snapsplit.backend.feature.getSharedDetails.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class UpdateDefaultCurrencyResponse {
+    private String before; // 변경 전 대표 통화코드
+    private String after; // 변경 후 대표 통화코드
+}

--- a/src/main/java/com/snapsplit/backend/feature/getSharedDetails/service/GetSharedDetailsService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getSharedDetails/service/GetSharedDetailsService.java
@@ -33,7 +33,6 @@ public class GetSharedDetailsService {
     private final TripRepository tripRepository;
     private final SharedRepository sharedRepository;
     private final ExpenseRepository expenseRepository;
-    private final PayRepository payRepository;
     private final TotalSharedRepository totalSharedRepository;
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/snapsplit/backend/feature/getSharedDetails/service/UpdateDefaultCurrencyService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getSharedDetails/service/UpdateDefaultCurrencyService.java
@@ -1,0 +1,45 @@
+package com.snapsplit.backend.feature.getSharedDetails.service;
+
+import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
+import com.snapsplit.backend.domain.totalshared.repository.TotalSharedRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.feature.getSharedDetails.dto.UpdateDefaultCurrencyResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateDefaultCurrencyService {
+
+    private final TripRepository tripRepository;
+    private final TotalSharedRepository totalSharedRepository;
+    @Transactional
+    public UpdateDefaultCurrencyResponse updateDefaultCurrency(Long tripId, String newCurrency) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
+
+        String before = trip.getDefaultCurrency(); // 기존 대표 통화값
+        tripRepository.updateDefaultCurrencyById(tripId, newCurrency); // 대표 통화 변경
+
+        // 이용 가능한 통화 목록
+        List<String> availCurrencies = totalSharedRepository.findByTrip(trip).stream()
+                .map(TotalShared::getTotalSharedCurrency)
+                .distinct()
+                .toList();
+
+        // 이용 가능한 통화 목록에 포함되어 있지 않다면
+        if (!availCurrencies.contains(newCurrency)) {
+            throw new IllegalArgumentException("선택한 통화는 현재 공동경비에 사용되지 않았습니다.");
+        }
+        
+        return UpdateDefaultCurrencyResponse.builder()
+                .before(before)
+                .after(newCurrency)
+                .build();
+    }
+
+}

--- a/src/main/java/com/snapsplit/backend/feature/getSharedDetails/service/UpdateDefaultCurrencyService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getSharedDetails/service/UpdateDefaultCurrencyService.java
@@ -23,7 +23,6 @@ public class UpdateDefaultCurrencyService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
 
         String before = trip.getDefaultCurrency(); // 기존 대표 통화값
-        tripRepository.updateDefaultCurrencyById(tripId, newCurrency); // 대표 통화 변경
 
         // 이용 가능한 통화 목록
         List<String> availCurrencies = totalSharedRepository.findByTrip(trip).stream()
@@ -35,6 +34,8 @@ public class UpdateDefaultCurrencyService {
         if (!availCurrencies.contains(newCurrency)) {
             throw new IllegalArgumentException("선택한 통화는 현재 공동경비에 사용되지 않았습니다.");
         }
+
+        tripRepository.updateDefaultCurrencyById(tripId, newCurrency); // 대표 통화 변경
         
         return UpdateDefaultCurrencyResponse.builder()
                 .before(before)


### PR DESCRIPTION
### ✨ 개요
사용자가 이용 가능한 통화 중 선택하여 대표 통화를 변경하는 기능

### ✅ 세부 내용
- 이용 가능한 통화 목록 중 선택하여 대표 통화 변경
- 변경하고자 하는 통화가 이용 가능한 통화 목록에 포함된 통화인지 검증

### 🔐 관련 API
- PATCH /trips/{tripId}/budget?newDefaultCur={}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 여행의 기본 통화(default currency)를 변경할 수 있는 API가 추가되었습니다. 이제 `/trips/{tripId}/budget` 엔드포인트에서 PATCH 요청으로 기본 통화를 업데이트할 수 있습니다.
  * 기본 통화 변경 시, 변경 전후의 통화 정보를 응답으로 제공합니다.

* **변경 사항**
  * 기존 `/trips/{tripId}/shared/details` 엔드포인트가 `/trips/{tripId}/budget/details`로 변경되었습니다.

* **버그 수정**
  * 서비스 내부 불필요한 필드가 제거되어 성능이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->