### PR TITLE
[Feat] 환율 API 통화 리스트 기반 요청으로 변경

### DIFF
--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
@@ -8,6 +8,7 @@ import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository
 import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.addExpense.dto.AddExpensePageResponse;
+import com.snapsplit.backend.feature.getExchangeRate.dto.ExchangeRateResponse;
 import com.snapsplit.backend.feature.getExchangeRate.service.ExchangeRateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -42,10 +43,11 @@ public class AddExpensePageService {
 
         // 3. 환율 정보 조회 (모든 통화에 대해)
         Map<String, BigDecimal> exchangeRates = new HashMap<>();
-        for (String cur : availCurrencies) {
-            var rateResponse = exchangeRateService.fetchExchangeRate(cur);
-            exchangeRates.put(cur, BigDecimal.valueOf(rateResponse.getRateToKrw()));
+        ExchangeRateResponse rateResponse = exchangeRateService.fetchExchangeRate(availCurrencies);
+        for (ExchangeRateResponse.ExchangeRateItem item : rateResponse.getRates()) {
+            exchangeRates.put(item.getCode(), item.getRateToBase());
         }
+
 
         // 4. 여행 멤버 목록
         List<AddExpensePageResponse.MemberDto> members = tripMemberRepository.findAllByTripId(trip.getId()).stream()

--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/controller/GetExchangeRateController.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/controller/GetExchangeRateController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -16,10 +18,10 @@ public class GetExchangeRateController {
 
     private final ExchangeRateService exchangeRateService;
 
-    @Operation(summary = "환율 조회", description = "원하는 국가의 현재 환율을 조회합니다.")
+    @Operation(summary = "환율 조회", description = "원하는 통화 코드 리스트에 대한 환율을 조회합니다.")
     @GetMapping("/exchangeRate")
-    public ApiResponse<ExchangeRateResponse> getExchangeRate(@RequestParam String base) {
-        ExchangeRateResponse result = exchangeRateService.fetchExchangeRate(base);
+    public ApiResponse<ExchangeRateResponse> getExchangeRates(@RequestParam List<String> bases) {
+        ExchangeRateResponse result = exchangeRateService.fetchExchangeRate(bases);
         return ApiResponse.success("환율 조회 성공", result);
     }
 

--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/dto/ExchangeRateResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/dto/ExchangeRateResponse.java
@@ -4,10 +4,19 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 
+import java.math.BigDecimal;
+import java.util.List;
+
 @Getter
 @Builder
 public class ExchangeRateResponse {
-    private String base; // 국가
-    private double rateToKrw; // 환율
-    private String date; // 환율을 받아온 날
+    private String date; // 기준일
+    private List<ExchangeRateItem> rates; // 여러 통화 환율 리스트
+
+    @Getter
+    @Builder
+    public static class ExchangeRateItem {
+        private String code; // 통화 코드 (ex. USD, EUR)
+        private BigDecimal rateToBase; // 기준 통화(KRW) 대비 환율
+    }
 }

--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
@@ -94,30 +94,34 @@ public class ExchangeRateService {
             throw new RuntimeException("JSON 파싱에 실패했습니다.", e);
         }
 
-        List<ExchangeRateResponse.ExchangeRateItem> resultRates = new ArrayList<>(upperBases.stream()
-                .filter(code -> !code.equalsIgnoreCase("KRW"))
-                .map(code -> {
-                    String unit = code.equals("JPY") ? "JPY(100)" : code;
-                    JSONObject matched = arr.stream()
-                            .map(JSONObject.class::cast)
-                            .filter(obj -> unit.equalsIgnoreCase(obj.getAsString("cur_unit")))
-                            .findFirst()
-                            .orElse(null);
+        List<ExchangeRateResponse.ExchangeRateItem> resultRates = new ArrayList<>();
 
-                    if (matched == null) throw new IllegalArgumentException("지원하지 않는 통화 코드: " + code);
+        for (String code : upperBases) {
+            if (code.equalsIgnoreCase("KRW")) continue;
 
-                    BigDecimal rate = new BigDecimal(matched.getAsString("deal_bas_r").replace(",", ""));
-                    if (code.equals("JPY")) rate = rate.divide(BigDecimal.valueOf(100));
+            String unit = code.equals("JPY") ? "JPY(100)" : code;
+            JSONObject matched = arr.stream()
+                    .map(JSONObject.class::cast)
+                    .filter(obj -> unit.equalsIgnoreCase(obj.getAsString("cur_unit")))
+                    .findFirst()
+                    .orElse(null);
 
-                    // Redis에 저장
-                    saveToRedis(code, rate, searchDate);
+            if (matched == null) throw new IllegalArgumentException("지원하지 않는 통화 코드: " + code);
 
-                    return ExchangeRateResponse.ExchangeRateItem.builder()
-                            .code(code)
-                            .rateToBase(rate)
-                            .build();
-                })
-                .toList());
+            BigDecimal rate = new BigDecimal(matched.getAsString("deal_bas_r").replace(",", ""));
+            if (code.equals("JPY")) {
+                rate = rate.divide(BigDecimal.valueOf(100));
+            }
+
+            // Redis 저장
+            saveToRedis(code, rate, searchDate);
+
+            resultRates.add(ExchangeRateResponse.ExchangeRateItem.builder()
+                    .code(code)
+                    .rateToBase(rate)
+                    .build());
+        }
+
 
         if (upperBases.contains("KRW")) {
             resultRates.add(ExchangeRateResponse.ExchangeRateItem.builder()

--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
@@ -174,26 +174,38 @@ public class ExchangeRateService {
         }
     }
 
-
-    // Redis Fallback
+    // Redis 캐시 조회
     private ExchangeRateResponse getFromRedis(List<String> codes, String date) {
-        List<ExchangeRateResponse.ExchangeRateItem> cachedItems = codes.stream()
-                .map(code -> {
-                    try {
-                        String json = redisTemplate.opsForValue().get("exchange:" + code);
-                        if (json == null) throw new RuntimeException("캐시 없음: " + code);
-                        ExchangeRateResponse cached = objectMapper.readValue(json, ExchangeRateResponse.class);
-                        return cached.getRates().get(0); // 각 통화별 하나씩만 들어있음
-                    } catch (Exception e) {
-                        throw new RuntimeException("Redis 캐시 조회 실패: " + code, e);
-                    }
-                })
-                .toList();
+        List<ExchangeRateResponse.ExchangeRateItem> cachedItems = new ArrayList<>();
+        List<String> failedCodes = new ArrayList<>();
+
+        for (String code : codes) {
+            try {
+                String json = redisTemplate.opsForValue().get("exchange:" + code);
+                if (json != null) {
+                    ExchangeRateResponse cached = objectMapper.readValue(json, ExchangeRateResponse.class);
+                    cachedItems.add(cached.getRates().get(0)); // 각 통화 하나씩만 있음
+                } else {
+                    failedCodes.add(code);
+                }
+            } catch (Exception e) {
+                log.warn("Redis 캐시 조회 실패: {}", code, e);
+                failedCodes.add(code);
+            }
+        }
+
+        if (!failedCodes.isEmpty()) {
+            log.error("다음 통화들의 캐시 조회 실패: {}", failedCodes);
+            if (cachedItems.isEmpty()) {
+                throw new RuntimeException("모든 통화의 캐시 조회 실패");
+            }
+        }
 
         return ExchangeRateResponse.builder()
                 .date(date)
                 .rates(cachedItems)
                 .build();
     }
+
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
@@ -24,6 +24,9 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -40,58 +43,54 @@ public class ExchangeRateService {
     @Value("${exchange-rate.timeout}")
     private int timeout;
 
-    public ExchangeRateResponse fetchExchangeRate(String base) {
-        // base가 krw일 경우 그냥 환율 1로 return
-        if (base.equalsIgnoreCase("KRW")) {
+    public ExchangeRateResponse fetchExchangeRate(List<String> bases) {
+
+        // 환율을 원하는 통화코드 리스트
+        List<String> upperBases = new ArrayList<>(bases.stream()
+                .map(String::toUpperCase)
+                .distinct()
+                .toList());
+
+        String searchDate = getLatestBusinessDay();
+
+        // KRW만 단독 요청 시
+        if (upperBases.size() == 1 && upperBases.contains("KRW")) {
             return ExchangeRateResponse.builder()
-                    .base("KRW")
-                    .rateToKrw(1.0)
-                    .date(getLatestBusinessDay())
+                    .date(searchDate)
+                    .rates(List.of(
+                            ExchangeRateResponse.ExchangeRateItem.builder()
+                                    .code("KRW")
+                                    .rateToBase(BigDecimal.ONE)
+                                    .build()
+                    ))
                     .build();
         }
-        
-        String searchDate = getLatestBusinessDay();
+
+        // API 요청
+        String url = "https://oapi.koreaexim.go.kr/site/program/financial/exchangeJSON"
+                + "?authkey=" + authKey
+                + "&searchdate=" + searchDate
+                + "&data=AP01";
+
         RestTemplate restTemplate = new RestTemplate();
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(timeout);
         factory.setReadTimeout(timeout);
         restTemplate.setRequestFactory(factory);
 
-        String url = "https://oapi.koreaexim.go.kr/site/program/financial/exchangeJSON"
-                + "?authkey=" + authKey
-                + "&searchdate=" + searchDate
-                + "&data=AP01";
-
         String response;
         try {
             response = restTemplate.getForObject(url, String.class);
-
             if (response == null || response.trim().isEmpty()) {
-                log.warn("환율 API 응답이 비어 있음. Redis 캐시 fallback 시도");
-
-                String redisKey = "exchange:" + base.toUpperCase();
-                try {
-                    String cachedJson = redisTemplate.opsForValue().get(redisKey);
-                    if (cachedJson != null) {
-                        ExchangeRateResponse cached = objectMapper.readValue(cachedJson, ExchangeRateResponse.class);
-                        log.info("Redis에서 환율 캐시 응답 반환: {}", cached);
-                        return cached;
-                    }
-                } catch (Exception e) {
-                    log.warn("Redis 캐시 조회 실패. 무시하고 예외 처리 진행", e);
-                }
-
-                throw new RuntimeException("환율 API 응답이 비어있고, Redis 캐시도 없습니다.");
+                log.warn("환율 API 응답 비어있음 → Redis fallback 시도");
+                return getFromRedis(upperBases, searchDate);
             }
-
-        } catch (ResourceAccessException e) {
-            throw new RuntimeException("환율 API 서버에 연결할 수 없습니다.", e);
-        } catch (HttpClientErrorException | HttpServerErrorException e) {
-            throw new RuntimeException("환율 API 호출 실패: " + e.getStatusCode(), e);
         } catch (Exception e) {
-            throw new RuntimeException("환율 API 요청 중 알 수 없는 에러가 발생했습니다.", e);
+            log.warn("환율 API 호출 실패 → Redis fallback 시도", e);
+            return getFromRedis(upperBases, searchDate);
         }
 
+        // 파싱
         JSONParser parser = new JSONParser();
         JSONArray arr;
         try {
@@ -100,45 +99,55 @@ public class ExchangeRateService {
             throw new RuntimeException("JSON 파싱에 실패했습니다.", e);
         }
 
-        JSONObject currencyObj = null;
-        String targetUnit = base.equalsIgnoreCase("JPY") ? "JPY(100)" : base.toUpperCase();
+        List<ExchangeRateResponse.ExchangeRateItem> resultRates = new ArrayList<>(upperBases.stream()
+                .filter(code -> !code.equalsIgnoreCase("KRW"))
+                .map(code -> {
+                    String unit = code.equals("JPY") ? "JPY(100)" : code;
+                    JSONObject matched = arr.stream()
+                            .map(JSONObject.class::cast)
+                            .filter(obj -> unit.equalsIgnoreCase(obj.getAsString("cur_unit")))
+                            .findFirst()
+                            .orElse(null);
 
-        for (Object o : arr) {
-            JSONObject obj = (JSONObject) o;
-            if (obj.getAsString("cur_unit").equalsIgnoreCase(targetUnit)) {
-                currencyObj = obj;
-                break;
-            }
+                    if (matched == null) throw new IllegalArgumentException("지원하지 않는 통화 코드: " + code);
+
+                    BigDecimal rate = new BigDecimal(matched.getAsString("deal_bas_r").replace(",", ""));
+                    if (code.equals("JPY")) rate = rate.divide(BigDecimal.valueOf(100));
+
+                    // Redis에 저장
+                    try {
+                        String json = objectMapper.writeValueAsString(ExchangeRateResponse.builder()
+                                .date(searchDate)
+                                .rates(List.of(
+                                        ExchangeRateResponse.ExchangeRateItem.builder()
+                                                .code(code)
+                                                .rateToBase(rate)
+                                                .build()))
+                                .build());
+                        redisTemplate.opsForValue().set("exchange:" + code, json, Duration.ofHours(24));
+                        log.info("Redis에 {} 저장 완료", code);
+                    } catch (Exception e) {
+                        log.warn("Redis 저장 실패: {}", code, e);
+                    }
+
+                    return ExchangeRateResponse.ExchangeRateItem.builder()
+                            .code(code)
+                            .rateToBase(rate)
+                            .build();
+                })
+                .toList());
+
+        if (upperBases.contains("KRW")) {
+            resultRates.add(ExchangeRateResponse.ExchangeRateItem.builder()
+                    .code("KRW")
+                    .rateToBase(BigDecimal.ONE)
+                    .build());
         }
 
-        if (currencyObj == null) {
-            throw new IllegalArgumentException("지원하지 않는 통화 코드: " + base);
-        }
-
-        String dealBasR = currencyObj.getAsString("deal_bas_r").replace(",", "");
-        BigDecimal rate = new BigDecimal(dealBasR);
-
-        // JPY는 100단위 처리
-        if (targetUnit.equals("JPY(100)")) {
-            rate = rate.divide(BigDecimal.valueOf(100));
-        }
-
-        ExchangeRateResponse result = ExchangeRateResponse.builder()
-                .base(base.toUpperCase())
-                .rateToKrw(rate.doubleValue())
+        return ExchangeRateResponse.builder()
                 .date(searchDate)
+                .rates(resultRates)
                 .build();
-
-        // Redis에 저장
-        try {
-            String json = objectMapper.writeValueAsString(result);
-            redisTemplate.opsForValue().set("exchange:" + base.toUpperCase(), json, Duration.ofHours(24));
-            log.info("Redis에 환율 저장 완료: {}", json);
-        } catch (Exception e) {
-            log.warn("Redis 저장 실패. 무시하고 진행", e);
-        }
-
-        return result;
 
     }
 
@@ -164,4 +173,26 @@ public class ExchangeRateService {
     private boolean isNonBusinessDay(LocalDate date) {
         return date.getDayOfWeek().getValue() >= 6 || holidayService.isHoliday(date);
     }
+
+    // Redis Fallback
+    private ExchangeRateResponse getFromRedis(List<String> codes, String date) {
+        List<ExchangeRateResponse.ExchangeRateItem> cachedItems = codes.stream()
+                .map(code -> {
+                    try {
+                        String json = redisTemplate.opsForValue().get("exchange:" + code);
+                        if (json == null) throw new RuntimeException("캐시 없음: " + code);
+                        ExchangeRateResponse cached = objectMapper.readValue(json, ExchangeRateResponse.class);
+                        return cached.getRates().get(0); // 각 통화별 하나씩만 들어있음
+                    } catch (Exception e) {
+                        throw new RuntimeException("Redis 캐시 조회 실패: " + code, e);
+                    }
+                })
+                .toList();
+
+        return ExchangeRateResponse.builder()
+                .date(date)
+                .rates(cachedItems)
+                .build();
+    }
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getExchangeRate/service/ExchangeRateService.java
@@ -10,12 +10,8 @@ import net.minidev.json.parser.JSONParser;
 import net.minidev.json.parser.ParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigDecimal;
@@ -26,7 +22,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Service
@@ -115,20 +110,7 @@ public class ExchangeRateService {
                     if (code.equals("JPY")) rate = rate.divide(BigDecimal.valueOf(100));
 
                     // Redis에 저장
-                    try {
-                        String json = objectMapper.writeValueAsString(ExchangeRateResponse.builder()
-                                .date(searchDate)
-                                .rates(List.of(
-                                        ExchangeRateResponse.ExchangeRateItem.builder()
-                                                .code(code)
-                                                .rateToBase(rate)
-                                                .build()))
-                                .build());
-                        redisTemplate.opsForValue().set("exchange:" + code, json, Duration.ofHours(24));
-                        log.info("Redis에 {} 저장 완료", code);
-                    } catch (Exception e) {
-                        log.warn("Redis 저장 실패: {}", code, e);
-                    }
+                    saveToRedis(code, rate, searchDate);
 
                     return ExchangeRateResponse.ExchangeRateItem.builder()
                             .code(code)
@@ -173,6 +155,25 @@ public class ExchangeRateService {
     private boolean isNonBusinessDay(LocalDate date) {
         return date.getDayOfWeek().getValue() >= 6 || holidayService.isHoliday(date);
     }
+
+    // 레디스에 저장
+    private void saveToRedis(String code, BigDecimal rate, String date) {
+        try {
+            String json = objectMapper.writeValueAsString(ExchangeRateResponse.builder()
+                    .date(date)
+                    .rates(List.of(
+                            ExchangeRateResponse.ExchangeRateItem.builder()
+                                    .code(code)
+                                    .rateToBase(rate)
+                                    .build()))
+                    .build());
+            redisTemplate.opsForValue().set("exchange:" + code, json, Duration.ofHours(24));
+            log.info("Redis에 {} 저장 완료", code);
+        } catch (Exception e) {
+            log.warn("Redis 저장 실패: {}", code, e);
+        }
+    }
+
 
     // Redis Fallback
     private ExchangeRateResponse getFromRedis(List<String> codes, String date) {

--- a/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/UpdateTotalSharedPageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/updateTotalShared/service/UpdateTotalSharedPageService.java
@@ -1,6 +1,7 @@
 package com.snapsplit.backend.feature.updateTotalShared.service;
 
 import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository;
+import com.snapsplit.backend.feature.getExchangeRate.dto.ExchangeRateResponse;
 import com.snapsplit.backend.feature.getExchangeRate.service.ExchangeRateService;
 import com.snapsplit.backend.feature.updateTotalShared.dto.UpdateTotalSharedPageResponse;
 import com.snapsplit.backend.feature.updateTotalShared.dto.UpdateTotalSharedPageResponse.CurrencyRate;
@@ -36,14 +37,13 @@ public class UpdateTotalSharedPageService {
         List<String> availCurrencies = new ArrayList<>(currencySet);
 
         // 환율 정보 조회 + CurrencyRate 객체로 변환
-        List<CurrencyRate> currencies = availCurrencies.stream()
-                .map(code -> {
-                    var rateResponse = exchangeRateService.fetchExchangeRate(code);
-                    return CurrencyRate.builder()
-                            .code(code)
-                            .exchangeRate(BigDecimal.valueOf(rateResponse.getRateToKrw()))
-                            .build();
-                })
+        ExchangeRateResponse response = exchangeRateService.fetchExchangeRate(availCurrencies);
+
+        List<CurrencyRate> currencies = response.getRates().stream()
+                .map(item -> CurrencyRate.builder()
+                        .code(item.getCode())
+                        .exchangeRate(item.getRateToBase())
+                        .build())
                 .collect(Collectors.toList());
 
         // 응답 반환


### PR DESCRIPTION
### ✨ 개요
- 기존 환율 API는 단일 통화에 대해서만 조회가 가능했음
- 여러 통화를 한 번에 조회하는 요청이 필요해져, API를 **다건 통화 조회 형태로 확장**함

### ✅ 세부 내용
- 단일 통화 기반 `fetchExchangeRate(String base)` → 다건 통화 기반 `fetchExchangeRate(List<String> bases)`로 변경
- 각 통화별로 Redis 캐싱 처리 (`exchange:{code}`)
- `KRW` 요청 시 환율 1.0으로 고정 반환 처리
- `JPY(100)`과 같은 특수 단위 변환 포함
- 기존 사용 로직에서도 새로운 구조 호환 가능하도록 인터페이스 설계

### 🔐 관련 API
- GET `/api/exchangeRate?base=USD` → GET `/api/exchangeRate?base=USD,EUR,JPY` 등으로 사용 가능

### 📝 참고 사항
- Redis TTL 24시간으로 설정되어 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 여러 통화의 환율을 한 번에 조회할 수 있도록 환율 조회 기능이 확장되었습니다.

* **버그 수정**
  * 환율 조회 시 각 통화별로 개별 호출하던 방식을 일괄 호출로 개선하여 성능이 향상되었습니다.

* **리팩터링**
  * 환율 응답 구조가 단일 통화에서 다중 통화 리스트로 변경되었습니다.
  * Redis 캐시를 활용하여 환율 조회의 신뢰성과 속도를 높였습니다.

* **문서화**
  * API 문서가 다중 통화 환율 조회를 반영하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->