### PR TITLE
[Feat] S3 연동하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     implementation 'org.springdoc:springdoc-openapi-starter-common:2.5.0'
 
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/snapsplit/backend/config/S3Config.java
+++ b/src/main/java/com/snapsplit/backend/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.snapsplit.backend.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/controller/CreateTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/controller/CreateTripController.java
@@ -1,17 +1,17 @@
 package com.snapsplit.backend.feature.createTrip.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
 import com.snapsplit.backend.feature.createTrip.dto.CreateTripRequest;
 import com.snapsplit.backend.feature.createTrip.dto.TripResponse;
 import com.snapsplit.backend.feature.createTrip.service.CreateTripService;
 import com.snapsplit.backend.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -23,19 +23,15 @@ public class CreateTripController {
     private final CreateTripService createTripService;
 
     // 신규 여행 등록하기
+    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "신규 여행 등록하기", description = "새로운 여행을 등록합니다.")
-    @PostMapping("/create")
-    public ResponseEntity<ApiResponse<List<TripResponse>>> createTrip(@RequestBody CreateTripRequest request) {
-        // 여행 생성 후 여행 아이디 리턴받기
-        Long tripId = createTripService.createTrip(request);
-        // 현재 시각 받아오기
+    public ResponseEntity<ApiResponse<List<TripResponse>>> createTrip(
+            @RequestPart("request") CreateTripRequest request,
+            @RequestPart(value = "tripImage", required = false) MultipartFile tripImageFile
+    ) throws IOException {
+        Long tripId = createTripService.createTrip(request, tripImageFile);
         String now = LocalDateTime.now().toString();
-
         TripResponse response = new TripResponse(tripId, now);
-        List<TripResponse> data = List.of(response);
-
-        return ResponseEntity.ok(
-                ApiResponse.success("여행이 성공적으로 등록되었습니다.", data)
-        );
+        return ResponseEntity.ok(ApiResponse.success("여행이 성공적으로 등록되었습니다.", List.of(response)));
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/dto/CreateTripRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/dto/CreateTripRequest.java
@@ -1,15 +1,16 @@
 package com.snapsplit.backend.feature.createTrip.dto;
 
 import lombok.Getter;
+import lombok.Setter;
+
 import java.util.List;
 
+@Setter
 @Getter
 public class CreateTripRequest {
-
     private String tripName; // 여행 이름
     private List<CountryDto> countries; // 여행 국가 리스트
     private String startDate; // 여행 시작일
     private String endDate; // 여행 종료일
     private List<Long> membersId; // 여행 멤버 리스트
-    private String tripImage; // 여행 대표 사진
 }

--- a/src/main/java/com/snapsplit/backend/feature/createTrip/service/CreateTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/createTrip/service/CreateTripService.java
@@ -12,10 +12,13 @@ import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.domain.user.repository.UserRepository;
 import com.snapsplit.backend.feature.createTrip.dto.CreateTripRequest;
+import com.snapsplit.backend.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.HashSet;
@@ -32,20 +35,27 @@ public class CreateTripService {
     private final TripMemberRepository tripMemberRepository;
     private final TotalSharedRepository totalSharedRepository;
     private final UserRepository userRepository;
+    private final S3Uploader s3Uploader;
 
     // 신규 여행 등록하기
     @Transactional
-    public Long createTrip(CreateTripRequest request) {
+    public Long createTrip(CreateTripRequest request, MultipartFile tripImageFile) throws IOException {
 
         // 8자리 랜덤 코드 생성
         String tripCode = generateTripCode();
+
+        // 여행 대표 사진 S3 업로드
+        String tripImageUrl = null;
+        if (tripImageFile != null && !tripImageFile.isEmpty()) {
+            tripImageUrl = s3Uploader.upload(tripImageFile, "trip-images");
+        }
 
         // Trip 생성
         Trip trip = Trip.builder()
                 .tripName(request.getTripName())
                 .startDate(LocalDate.parse(request.getStartDate()))
                 .endDate(LocalDate.parse(request.getEndDate()))
-                .tripImage(request.getTripImage())
+                .tripImage(tripImageUrl)
                 .tripTotalExpense(BigDecimal.ZERO)
                 .tripCode(tripCode)
                 .defaultCurrency("KRW")

--- a/src/main/java/com/snapsplit/backend/feature/myPage/controller/MyPageController.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/controller/MyPageController.java
@@ -1,19 +1,24 @@
 package com.snapsplit.backend.feature.myPage.controller;
 
 import com.snapsplit.backend.domain.user.repository.UserRepository;
-import com.snapsplit.backend.feature.myPage.dto.MyPageUpdateRequest;
 import com.snapsplit.backend.feature.myPage.dto.MyPageResponse;
 import com.snapsplit.backend.feature.myPage.service.MyPageService;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.global.response.ApiResponse;
+import com.snapsplit.backend.global.s3.S3Uploader;
 import com.snapsplit.backend.global.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +27,7 @@ public class MyPageController {
 
     private final MyPageService myPageService;
     private final UserRepository userRepository;
+    private final S3Uploader s3Uploader;
 
     // GET /home/myPage
     // 마이페이지 조회
@@ -40,15 +46,22 @@ public class MyPageController {
     // PUT /home/myPage
     // 마이페이지 수정
     @Operation(summary = "마이페이지 수정", description = "기존 마이페이지 정보를 수정합니다.")
-    @PutMapping
+    @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> updateProfile(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @RequestBody MyPageUpdateRequest request
-    ) {
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) MultipartFile profileImage
+    ) throws IOException {
         Long userId = principal.getId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
-        myPageService.updateProfile(user, request.name(), request.profileImageUrl());
+
+        String profileImageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            profileImageUrl = s3Uploader.upload(profileImage, "profile");
+        }
+
+        myPageService.updateProfile(user, name, profileImageUrl);
         return ResponseEntity.ok(ApiResponse.success("프로필 수정 완료", null));
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/myPage/dto/MyPageUpdateRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/myPage/dto/MyPageUpdateRequest.java
@@ -1,6 +1,0 @@
-package com.snapsplit.backend.feature.myPage.dto;
-
-public record MyPageUpdateRequest(
-        String name,
-        String profileImageUrl
-) {}

--- a/src/main/java/com/snapsplit/backend/global/s3/S3Uploader.java
+++ b/src/main/java/com/snapsplit/backend/global/s3/S3Uploader.java
@@ -1,0 +1,33 @@
+package com.snapsplit.backend.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.UUID;
+
+
+@Service
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile file, String dirName) throws IOException {
+        String fileName = dirName + "/" + UUID.randomUUID() + "-" + file.getOriginalFilename();
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        amazonS3.putObject(bucket, fileName, file.getInputStream(), metadata);
+
+        return amazonS3.getUrl(bucket, fileName).toString(); // URL 반환
+    }
+}


### PR DESCRIPTION
### ✨ 개요
오브젝트 스토리지 연동하여 imageUrl을 반환받아 DB에 저장하기

### ✅ 작업 내용
- 기존 application/json에서 imageUrl로 처리하던 이미지 등록/수정을 multipart/form-data로 수정 
- 마이페이지 수정, 여행 생성하기에 각각 적용

### 🔐 관련 API
- PUT /home/myPage
- POST /trips/create

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영됨
- 여행 수정하기 로직은 다른 브랜치에서 작업중이어서 merge 후 이어서 함께 반영 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * Amazon S3에 파일 업로드를 지원하는 기능이 추가되었습니다.
  * 여행 생성 시 이미지 파일을 첨부할 수 있습니다.
  * 마이페이지 프로필 이미지 변경 시 파일 업로드가 가능합니다.

* **버그 수정**
  * 없음

* **리팩터**
  * 여행 생성 및 프로필 업데이트 요청 방식을 multipart/form-data로 변경하였습니다.

* **기타**
  * 관련 DTO 및 서비스 클래스가 추가/삭제되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->