### PR TITLE
[Feat] 여행 수정/삭제하기

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
@@ -15,6 +15,7 @@ import java.util.List;
 @Entity
 @Table(name = "trip")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
+++ b/src/main/java/com/snapsplit/backend/domain/trip/entity/Trip.java
@@ -28,9 +28,11 @@ public class Trip {
     @Column(name = "trip_name", length = 100, nullable = false)
     private String tripName; // 여행 이름
 
+    @Setter
     @Column(nullable = false)
     private LocalDate startDate; // 시작일
 
+    @Setter
     @Column(nullable = false)
     private LocalDate endDate; // 종료일
 

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
@@ -1,9 +1,6 @@
 package com.snapsplit.backend.feature.editTrip.controller;
 
-import com.snapsplit.backend.feature.editTrip.dto.CountriesResponse;
-import com.snapsplit.backend.feature.editTrip.dto.ScheduleResponse;
-import com.snapsplit.backend.feature.editTrip.dto.UpdateCountriesRequest;
-import com.snapsplit.backend.feature.editTrip.dto.UpdateScheduleRequest;
+import com.snapsplit.backend.feature.editTrip.dto.*;
 import com.snapsplit.backend.feature.editTrip.service.EditTripService;
 import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
@@ -57,6 +54,14 @@ public class EditTripController {
     ) {
         editTripService.updateTripSchedule(tripId, request);
         return ResponseEntity.ok(ApiResponse.success("여행 일정 수정 성공",null));
+    }
+
+    @CheckTripMember
+    @Operation(summary = "여행 이름 및 대표 이미지 조회", description = "여행 제목과 대표 이미지를 조회합니다.")
+    @GetMapping("/{tripId}/info")
+    public ResponseEntity<ApiResponse<TripInfoResponse>> getTripInfo(@PathVariable Long tripId) {
+        TripInfoResponse response = editTripService.getTripInfo(tripId);
+        return ResponseEntity.ok(ApiResponse.success("여행 정보 조회 성공", response));
     }
 
 

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
@@ -65,4 +65,15 @@ public class EditTripController {
     }
 
 
+
+
+    @CheckTripMember
+    @Operation(summary = "여행 삭제", description = "해당 여행과 관련된 모든 데이터를 삭제합니다.")
+    @DeleteMapping("/{tripId}")
+    public ResponseEntity<ApiResponse<Void>> deleteTrip(@PathVariable Long tripId) {
+        editTripService.deleteTrip(tripId);
+        return ResponseEntity.ok(ApiResponse.success("여행 삭제 성공", null));
+    }
+
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
@@ -6,8 +6,12 @@ import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -64,8 +68,17 @@ public class EditTripController {
         return ResponseEntity.ok(ApiResponse.success("여행 정보 조회 성공", response));
     }
 
-
-
+    @CheckTripMember
+    @Operation(summary = "여행 이름 및 대표 이미지 수정", description = "여행의 제목과 대표 이미지를 수정합니다.")
+    @PatchMapping(value = "/{tripId}/info", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> updateTripInfo(
+            @PathVariable Long tripId,
+            @RequestPart(value = "tripName", required = false) String tripName,
+            @RequestPart(value = "tripImageFile", required = false) MultipartFile tripImageFile
+    ) throws IOException {
+        editTripService.updateTripInfo(tripId, tripName, tripImageFile);
+        return ResponseEntity.ok(ApiResponse.success("여행 정보 수정 성공", null));
+    }
 
     @CheckTripMember
     @Operation(summary = "여행 삭제", description = "해당 여행과 관련된 모든 데이터를 삭제합니다.")

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
@@ -1,6 +1,7 @@
 package com.snapsplit.backend.feature.editTrip.controller;
 
 import com.snapsplit.backend.feature.editTrip.dto.CountriesResponse;
+import com.snapsplit.backend.feature.editTrip.dto.ScheduleResponse;
 import com.snapsplit.backend.feature.editTrip.dto.UpdateCountriesRequest;
 import com.snapsplit.backend.feature.editTrip.service.EditTripService;
 import com.snapsplit.backend.global.aop.CheckTripMember;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class EditTripController {
 
     private final EditTripService editTripService;
+
     @CheckTripMember
     @Operation(summary = "여행 국가 조회", description = "기존에 등록된 여행 국가 목록을 불러옵니다.")
     @GetMapping("/{tripId}/countries")
@@ -33,6 +35,16 @@ public class EditTripController {
     ) {
         editTripService.updateCountries(tripId, request);
         return ResponseEntity.ok(ApiResponse.<Void>success("여행 국가 수정 성공", null));
+    }
+
+    @CheckTripMember
+    @Operation(summary = "여행 일정 조회", description = "기존 여행의 시작일과 종료일을 조회합니다.")
+    @GetMapping("/{tripId}/schedule")
+    public ResponseEntity<ApiResponse<ScheduleResponse>> getTripSchedule(
+            @PathVariable Long tripId
+    ) {
+        ScheduleResponse response = editTripService.getTripSchedule(tripId);
+        return ResponseEntity.ok(ApiResponse.success("여행 일정 조회 성공", response));
     }
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
@@ -3,6 +3,7 @@ package com.snapsplit.backend.feature.editTrip.controller;
 import com.snapsplit.backend.feature.editTrip.dto.CountriesResponse;
 import com.snapsplit.backend.feature.editTrip.dto.ScheduleResponse;
 import com.snapsplit.backend.feature.editTrip.dto.UpdateCountriesRequest;
+import com.snapsplit.backend.feature.editTrip.dto.UpdateScheduleRequest;
 import com.snapsplit.backend.feature.editTrip.service.EditTripService;
 import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
@@ -46,5 +47,17 @@ public class EditTripController {
         ScheduleResponse response = editTripService.getTripSchedule(tripId);
         return ResponseEntity.ok(ApiResponse.success("여행 일정 조회 성공", response));
     }
+
+    @CheckTripMember
+    @Operation(summary = "여행 일정 수정", description = "여행의 시작일과 종료일을 수정합니다.")
+    @PatchMapping("/{tripId}/schedule")
+    public ResponseEntity<ApiResponse<Void>> updateTripSchedule(
+            @PathVariable Long tripId,
+            @RequestBody UpdateScheduleRequest request
+    ) {
+        editTripService.updateTripSchedule(tripId, request);
+        return ResponseEntity.ok(ApiResponse.success("여행 일정 수정 성공",null));
+    }
+
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/controller/EditTripController.java
@@ -1,0 +1,38 @@
+package com.snapsplit.backend.feature.editTrip.controller;
+
+import com.snapsplit.backend.feature.editTrip.dto.CountriesResponse;
+import com.snapsplit.backend.feature.editTrip.dto.UpdateCountriesRequest;
+import com.snapsplit.backend.feature.editTrip.service.EditTripService;
+import com.snapsplit.backend.global.aop.CheckTripMember;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trips")
+public class EditTripController {
+
+    private final EditTripService editTripService;
+    @CheckTripMember
+    @Operation(summary = "여행 국가 조회", description = "기존에 등록된 여행 국가 목록을 불러옵니다.")
+    @GetMapping("/{tripId}/countries")
+    public ResponseEntity<ApiResponse<CountriesResponse>> getTripCountries(@PathVariable Long tripId) {
+        CountriesResponse response = editTripService.getTripCountries(tripId);
+        return ResponseEntity.ok(ApiResponse.success("여행 국가 조회 성공", response));
+    }
+
+    @CheckTripMember
+    @Operation(summary = "여행 국가 수정", description = "기존에 등록된 여행 국가 목록을 수정합니다.")
+    @PatchMapping("/{tripId}/countries")
+    public ResponseEntity<ApiResponse> updateTripCountries(
+            @PathVariable Long tripId,
+            @RequestBody UpdateCountriesRequest request
+    ) {
+        editTripService.updateCountries(tripId, request);
+        return ResponseEntity.ok(ApiResponse.<Void>success("여행 국가 수정 성공", null));
+    }
+
+}

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/dto/CountriesResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/dto/CountriesResponse.java
@@ -1,0 +1,12 @@
+package com.snapsplit.backend.feature.editTrip.dto;
+
+import java.util.List;
+
+public record CountriesResponse(
+        List<CountryDto> countries
+) {
+    public record CountryDto(
+            Long countryId,
+            String countryName
+    ) {}
+}

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/dto/ScheduleResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/dto/ScheduleResponse.java
@@ -1,0 +1,8 @@
+package com.snapsplit.backend.feature.editTrip.dto;
+
+import java.time.LocalDate;
+
+public record ScheduleResponse(
+        LocalDate startDate,
+        LocalDate endDate
+) {}

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/dto/TripInfoResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/dto/TripInfoResponse.java
@@ -1,0 +1,6 @@
+package com.snapsplit.backend.feature.editTrip.dto;
+
+public record TripInfoResponse(
+        String tripName,
+        String tripImage
+) {}

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/dto/UpdateCountriesRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/dto/UpdateCountriesRequest.java
@@ -1,0 +1,15 @@
+package com.snapsplit.backend.feature.editTrip.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public record UpdateCountriesRequest(
+        List<CountryDto> countries
+) {
+    @Builder
+    public record CountryDto(
+            Long countryId,
+            String countryName
+    ) {}
+}

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/dto/UpdateScheduleRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/dto/UpdateScheduleRequest.java
@@ -1,0 +1,8 @@
+package com.snapsplit.backend.feature.editTrip.dto;
+
+import java.time.LocalDate;
+
+public record UpdateScheduleRequest(
+        LocalDate startDate,
+        LocalDate endDate
+) {}

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
@@ -4,10 +4,7 @@ import com.snapsplit.backend.domain.country.repository.CountryRepository;
 import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.trip.repository.TripRepository;
 import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
-import com.snapsplit.backend.feature.editTrip.dto.CountriesResponse;
-import com.snapsplit.backend.feature.editTrip.dto.ScheduleResponse;
-import com.snapsplit.backend.feature.editTrip.dto.UpdateCountriesRequest;
-import com.snapsplit.backend.feature.editTrip.dto.UpdateScheduleRequest;
+import com.snapsplit.backend.feature.editTrip.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -85,5 +82,18 @@ public class EditTripService {
 
         trip.setStartDate(request.startDate());
         trip.setEndDate(request.endDate());
+    }
+
+    // 수정 전 여행명 및 대표 사진 불러오기
+    @Transactional(readOnly = true)
+    public TripInfoResponse getTripInfo(Long tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "해당 여행이 존재하지 않습니다."));
+
+        return new TripInfoResponse(
+                trip.getTripName(),
+                trip.getTripImage()
+        );
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
@@ -5,6 +5,7 @@ import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.trip.repository.TripRepository;
 import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
 import com.snapsplit.backend.feature.editTrip.dto.CountriesResponse;
+import com.snapsplit.backend.feature.editTrip.dto.ScheduleResponse;
 import com.snapsplit.backend.feature.editTrip.dto.UpdateCountriesRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +22,7 @@ public class EditTripService {
     private final TripRepository tripRepository;
     private final CountryRepository countryRepository;
 
+    // 수정 전 여행지 불러오기
     @Transactional(readOnly = true)
     public CountriesResponse getTripCountries(Long tripId) {
         Trip trip = tripRepository.findById(tripId)
@@ -37,6 +39,7 @@ public class EditTripService {
         return new CountriesResponse(countryDtos);
     }
 
+    // 여행지 수정하기
     @Transactional
     public void updateCountries(Long tripId, UpdateCountriesRequest request) {
         Trip trip = tripRepository.findById(tripId)
@@ -60,5 +63,15 @@ public class EditTripService {
                 .toList();
 
         trip.getTripCountries().addAll(newTripCountries);
+    }
+
+    //수정 전 여행 일정 불러오기
+    @Transactional(readOnly = true)
+    public ScheduleResponse getTripSchedule(Long tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "해당 여행이 존재하지 않습니다."));
+
+        return new ScheduleResponse(trip.getStartDate(), trip.getEndDate());
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
@@ -96,4 +96,18 @@ public class EditTripService {
                 trip.getTripImage()
         );
     }
+
+
+
+
+
+    // 여행 삭제하기
+    @Transactional
+    public void deleteTrip(Long tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "해당 여행이 존재하지 않습니다."));
+
+        tripRepository.delete(trip);
+    }
 }

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
@@ -7,6 +7,7 @@ import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
 import com.snapsplit.backend.feature.editTrip.dto.CountriesResponse;
 import com.snapsplit.backend.feature.editTrip.dto.ScheduleResponse;
 import com.snapsplit.backend.feature.editTrip.dto.UpdateCountriesRequest;
+import com.snapsplit.backend.feature.editTrip.dto.UpdateScheduleRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -65,7 +66,7 @@ public class EditTripService {
         trip.getTripCountries().addAll(newTripCountries);
     }
 
-    //수정 전 여행 일정 불러오기
+    // 수정 전 여행 일정 불러오기
     @Transactional(readOnly = true)
     public ScheduleResponse getTripSchedule(Long tripId) {
         Trip trip = tripRepository.findById(tripId)
@@ -73,5 +74,16 @@ public class EditTripService {
                         HttpStatus.NOT_FOUND, "해당 여행이 존재하지 않습니다."));
 
         return new ScheduleResponse(trip.getStartDate(), trip.getEndDate());
+    }
+
+    // 여행 일정 수정하기
+    @Transactional
+    public void updateTripSchedule(Long tripId, UpdateScheduleRequest request) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "해당 여행이 존재하지 않습니다."));
+
+        trip.setStartDate(request.startDate());
+        trip.setEndDate(request.endDate());
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
@@ -5,12 +5,15 @@ import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.trip.repository.TripRepository;
 import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
 import com.snapsplit.backend.feature.editTrip.dto.*;
+import com.snapsplit.backend.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -19,6 +22,7 @@ public class EditTripService {
 
     private final TripRepository tripRepository;
     private final CountryRepository countryRepository;
+    private final S3Uploader s3Uploader;
 
     // 수정 전 여행지 불러오기
     @Transactional(readOnly = true)
@@ -97,7 +101,24 @@ public class EditTripService {
         );
     }
 
+    // 여행명 및 대표 사진 수정하기
+    @Transactional
+    public void updateTripInfo(Long tripId, String tripName, MultipartFile tripImageFile) throws IOException {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "해당 여행이 존재하지 않습니다."));
 
+        // 여행 이름 수정
+        if (tripName != null && !tripName.trim().isEmpty()) {
+            trip.setTripName(tripName);
+        }
+
+        // 대표 이미지 수정
+        if (tripImageFile != null && !tripImageFile.isEmpty()) {
+            String imageUrl = s3Uploader.upload(tripImageFile, "trip-images");
+            trip.setTripImage(imageUrl);
+        }
+    }
 
 
 

--- a/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/editTrip/service/EditTripService.java
@@ -1,0 +1,64 @@
+package com.snapsplit.backend.feature.editTrip.service;
+import com.snapsplit.backend.domain.country.entity.Country;
+import com.snapsplit.backend.domain.country.repository.CountryRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.domain.tripcountry.entity.TripCountry;
+import com.snapsplit.backend.feature.editTrip.dto.CountriesResponse;
+import com.snapsplit.backend.feature.editTrip.dto.UpdateCountriesRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EditTripService {
+
+    private final TripRepository tripRepository;
+    private final CountryRepository countryRepository;
+
+    @Transactional(readOnly = true)
+    public CountriesResponse getTripCountries(Long tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "해당 여행이 존재하지 않습니다."));
+
+        List<CountriesResponse.CountryDto> countryDtos = trip.getTripCountries().stream()
+                .map(tripCountry -> new CountriesResponse.CountryDto(
+                        tripCountry.getCountry().getId(),
+                        tripCountry.getCountry().getCountryName()
+                ))
+                .toList();
+
+        return new CountriesResponse(countryDtos);
+    }
+
+    @Transactional
+    public void updateCountries(Long tripId, UpdateCountriesRequest request) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "해당 여행이 존재하지 않습니다."));
+
+        // 기존 여행지 목록 초기화 (orphanRemoval = true 덕분에 자동 삭제)
+        trip.getTripCountries().clear();
+
+        // 새로운 국가 목록 설정
+        List<TripCountry> newTripCountries = request.countries().stream()
+                .map(dto -> {
+                    Country country = countryRepository.findById(dto.countryId())
+                            .orElseThrow(() -> new ResponseStatusException(
+                                    HttpStatus.BAD_REQUEST, "존재하지 않는 국가 ID입니다."));
+                    return TripCountry.builder()
+                            .trip(trip)
+                            .country(country)
+                            .build();
+                })
+                .toList();
+
+        trip.getTripCountries().addAll(newTripCountries);
+    }
+}


### PR DESCRIPTION
### ✨ 개요
여행 생성 후 여행을 수정하는 로직 구현

### ✅ 작업 내용
- 수정 전 여행지 불러오기, 여행지 수정하기
- 수정 전 여행 일정 불러오기, 여행 일정 수정하기
- 수정 전 여행명/대표사진 불러오기, 여행명/대표사진 수정하기
  - S3연동 완료
- 여행 삭제하기

### 🔐 관련 API
- GET /trips/{tripId}/countries
- PATCH /trips/{tripId}/countries
- GET /trips/{tripId}/schedule
- PATCH /trips/{tripId}/schedule
- GET /trips/{tripId}/info
- PATCH /trips/{tripId}/info
- DELETE /trips/{tripId}

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여행 정보 수정 기능이 추가되었습니다. 이제 여행의 국가 목록, 일정(시작일/종료일), 이름, 대표 이미지를 조회 및 수정할 수 있습니다.
  * 여행 삭제 기능이 추가되었습니다.
  * 각 기능별로 일관된 API 응답 형식과 Swagger 문서가 제공됩니다.

* **버그 수정**
  * 없음

* **기타**
  * 여행 정보 관련 요청 시 멤버십 인증이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->