### PR TITLE
[Feat] 정산 영수증 시작 페이지 조회 / 정산하기 / 정산 영수증 상세정보 조회

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/expense/entity/Pay.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/entity/Pay.java
@@ -1,5 +1,6 @@
 package com.snapsplit.backend.domain.expense.entity;
 
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import jakarta.persistence.*;
 import lombok.*;
 import java.math.BigDecimal;
@@ -22,6 +23,10 @@ public class Pay {
 
     @Column(name = "payer_id", nullable = false)
     private Long payerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payer_id", insertable = false, updatable = false)
+    private TripMember payer;
 
     @Column(name = "pay_amount", nullable = false, precision = 10, scale = 2)
     private BigDecimal payAmount;

--- a/src/main/java/com/snapsplit/backend/domain/expense/entity/Split.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/entity/Split.java
@@ -1,5 +1,6 @@
 package com.snapsplit.backend.domain.expense.entity;
 
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import jakarta.persistence.*;
 import lombok.*;
 import java.math.BigDecimal;
@@ -28,5 +29,9 @@ public class Split {
 
     @Column(name = "split_amount_krw", nullable = false, precision = 10, scale = 2)
     private BigDecimal splitAmountKrw;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "splitter_id", insertable = false, updatable = false)
+    private TripMember splitter;
 }
 

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/ExpenseRepository.java
@@ -2,10 +2,16 @@ package com.snapsplit.backend.domain.expense.repository;
 
 import com.snapsplit.backend.domain.expense.entity.Expense;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     List<Expense> findAllByTripId(Long tripId);
 
+    // 여행 ID + 날짜 범위 조건으로 Expense 조회
+    List<Expense> findByTripIdAndExpenseDateBetween(Long tripId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
@@ -6,7 +6,10 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 public interface PayRepository extends JpaRepository<Pay, Long> {
 
@@ -17,4 +20,6 @@ public interface PayRepository extends JpaRepository<Pay, Long> {
     @Query("DELETE FROM Pay p WHERE p.expenseId = :expenseId")
     void deleteByExpenseId(@Param("expenseId") Long expenseId);
 
+    // 여러 개의 expenseId에 대해서 Pay 검색
+    List<Pay> findAllByExpenseIdIn(List<Long> expenseIds);
 }

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
@@ -17,4 +17,6 @@ public interface SplitRepository extends JpaRepository<Split, Long> {
     @Query("DELETE FROM Split s WHERE s.expenseId = :expenseId")
     void deleteByExpenseId(@Param("expenseId") Long expenseId);
 
+    // 여러 개의 expenseId에 대해 Split 검색
+    List<Split> findAllByExpenseIdIn(List<Long> expenseIds);
 }

--- a/src/main/java/com/snapsplit/backend/domain/settlement/entity/Settlement.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/entity/Settlement.java
@@ -1,0 +1,39 @@
+package com.snapsplit.backend.domain.settlement.entity;
+
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "settlement")
+public class Settlement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 정산 아이디
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip; // 여행 아이디
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDate createdAt; // 정산 생성일자
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate; // 정산 시작일
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate; // 정산 종료일
+
+    // 정산 세부내역 1 : N 관계
+    @OneToMany(mappedBy = "settlement", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SettlementDetail> details = new ArrayList<>();
+}

--- a/src/main/java/com/snapsplit/backend/domain/settlement/entity/Settlement.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/entity/Settlement.java
@@ -33,7 +33,7 @@ public class Settlement {
     @Column(name = "end_date", nullable = false)
     private LocalDate endDate; // 정산 종료일
 
-    // 정산 세부내역 1 : N 관계
     @OneToMany(mappedBy = "settlement", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<SettlementDetail> details = new ArrayList<>();
 }

--- a/src/main/java/com/snapsplit/backend/domain/settlement/entity/SettlementDetail.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/entity/SettlementDetail.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/snapsplit/backend/domain/settlement/entity/SettlementDetail.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/entity/SettlementDetail.java
@@ -1,0 +1,36 @@
+package com.snapsplit.backend.domain.settlement.entity;
+
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import com.snapsplit.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "settlement_detail")
+public class SettlementDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 정산 세부내역 아이디
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "settlement_id", nullable = false)
+    private Settlement settlement; // 정산 아이디
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private TripMember sender; // 보낼 TripMember
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private TripMember receiver; // 받을 TripMember
+
+    @Column(name = "amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal amount; // 보낼 금액
+}

--- a/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementDetailRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementDetailRepository.java
@@ -3,5 +3,8 @@ package com.snapsplit.backend.domain.settlement.repository;
 import com.snapsplit.backend.domain.settlement.entity.SettlementDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SettlementDetailRepository extends JpaRepository<SettlementDetail, Long> {
+    List<SettlementDetail> findAllBySettlementId(Long settlementId);
 }

--- a/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementDetailRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementDetailRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.settlement.repository;
+
+import com.snapsplit.backend.domain.settlement.entity.SettlementDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementDetailRepository extends JpaRepository<SettlementDetail, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementRepository.java
@@ -1,0 +1,7 @@
+package com.snapsplit.backend.domain.settlement.repository;
+
+import com.snapsplit.backend.domain.settlement.entity.Settlement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+}

--- a/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementRepository.java
@@ -3,5 +3,8 @@ package com.snapsplit.backend.domain.settlement.repository;
 import com.snapsplit.backend.domain.settlement.entity.Settlement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+    List<Settlement> findAllByTripId(Long tripId);
 }

--- a/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
@@ -50,4 +50,8 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
     List<TripMember> findAllByTripId(Long tripId);
     
     boolean existsByTripAndUser(Trip trip, User user); // 이미 여행에 참여한 사용자인지 확인
+
+    @Query("SELECT tm FROM TripMember tm JOIN FETCH tm.user WHERE tm.trip.id = :tripId")
+    List<TripMember> findAllByTripIdWithUser(@Param("tripId") Long tripId);
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementController.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementController.java
@@ -1,5 +1,6 @@
 package com.snapsplit.backend.feature.settlement.controller;
 
+import com.snapsplit.backend.feature.settlement.dto.SettlementCreationResponse;
 import com.snapsplit.backend.feature.settlement.dto.SettlementRequest;
 import com.snapsplit.backend.feature.settlement.service.SettlementDetailService;
 import com.snapsplit.backend.feature.settlement.service.SettlementService;
@@ -23,12 +24,14 @@ public class SettlementController {
     @Operation(summary = "정산하기", description = "정산 시작일 및 종료일을 기반으로 정산을 처리합니다.")
     @PostMapping("/{tripId}/settlements")
     @CheckTripMember
-    public ApiResponse<List<Map<String, Long>>> createSettlement(@PathVariable Long tripId,
-                                                                 @RequestBody SettlementRequest request) {
+    public ApiResponse<SettlementCreationResponse> createSettlement(@PathVariable Long tripId,
+                                                                    @RequestBody SettlementRequest request) {
         Long settlementId = settlementService.createSettlement(tripId, request);
 
-        return ApiResponse.success("정산이 완료되었습니다.",
-                List.of(Map.of("settlementId", settlementId)));
+        return ApiResponse.success(
+                "정산이 완료되었습니다.",
+                new SettlementCreationResponse(settlementId)
+        );
     }
 
     @Operation(summary = "정산 영수증 상세 조회", description = "정산 ID를 기반으로 정산 상세 내역을 조회합니다.")

--- a/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementController.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementController.java
@@ -1,0 +1,45 @@
+package com.snapsplit.backend.feature.settlement.controller;
+
+import com.snapsplit.backend.feature.settlement.dto.SettlementRequest;
+import com.snapsplit.backend.feature.settlement.service.SettlementDetailService;
+import com.snapsplit.backend.feature.settlement.service.SettlementService;
+import com.snapsplit.backend.global.aop.CheckTripMember;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trips")
+public class SettlementController {
+
+    private final SettlementService settlementService;
+    private final SettlementDetailService settlementDetailService;
+
+    @Operation(summary = "정산하기", description = "정산 시작일 및 종료일을 기반으로 정산을 처리합니다.")
+    @PostMapping("/{tripId}/settlements")
+    @CheckTripMember
+    public ApiResponse<List<Map<String, Long>>> createSettlement(@PathVariable Long tripId,
+                                                                 @RequestBody SettlementRequest request) {
+        Long settlementId = settlementService.createSettlement(tripId, request);
+
+        return ApiResponse.success("정산이 완료되었습니다.",
+                List.of(Map.of("settlementId", settlementId)));
+    }
+
+    @Operation(summary = "정산 영수증 상세 조회", description = "정산 ID를 기반으로 정산 상세 내역을 조회합니다.")
+    @GetMapping("/{tripId}/settlement")
+    @CheckTripMember
+    public ApiResponse<?> getSettlementDetails(@PathVariable Long tripId,
+                                               @RequestParam Long settlementId) {
+        return ApiResponse.success(
+                "정산 상세 내역 조회 성공",
+                settlementDetailService.getSettlementDetails(tripId, settlementId)
+        );
+    }
+
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementPageController.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementPageController.java
@@ -1,0 +1,25 @@
+package com.snapsplit.backend.feature.settlement.controller;
+
+import com.snapsplit.backend.feature.settlement.dto.SettlementPageResponse;
+import com.snapsplit.backend.feature.settlement.service.SettlementPageService;
+import com.snapsplit.backend.global.aop.CheckTripMember;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trips")
+public class SettlementPageController {
+
+    private final SettlementPageService settlementPageService;
+
+    @Operation(summary = "정산 영수증 시작 페이지 조회", description = "이미 정산완료된 정산 영수증 내역 날짜 정보와 여행 시작일 및 종료일을 제공합니다.")
+    @GetMapping("/{tripId}/settlements")
+    @CheckTripMember
+    public ApiResponse<SettlementPageResponse> getSettlementPage(@PathVariable Long tripId) {
+        SettlementPageResponse response = settlementPageService.getSettlementPage(tripId);
+        return ApiResponse.success("정산 페이지 조회 성공", response);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementCreationResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementCreationResponse.java
@@ -1,0 +1,10 @@
+package com.snapsplit.backend.feature.settlement.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SettlementCreationResponse {
+    private Long settlementId;
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementDetailResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementDetailResponse.java
@@ -1,5 +1,6 @@
 package com.snapsplit.backend.feature.settlement.dto;
 
+import com.snapsplit.backend.domain.expense.entity.Pay;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementDetailResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementDetailResponse.java
@@ -1,0 +1,41 @@
+package com.snapsplit.backend.feature.settlement.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@Builder
+public class SettlementDetailResponse {
+    private Long id; // 정산 ID
+    private List<Member> members; // 여행 멤버 리스트
+    private List<SettlementDetail> settlementDetails; // 정산 세부 내역
+    private List<PersonalExpense> personalExpenses; // 개인 지출 내역
+    private BigDecimal totalAmount; // 총 지출 합계
+
+    @Data
+    @Builder
+    public static class Member {
+        private Long memberId; // 트립 멤버 아이디
+        private String name; // 이름
+    }
+
+    @Data
+    @Builder
+    public static class SettlementDetail {
+        private Member sender; // 보내는 사람
+        private Member receiver; // 받는 사람
+        private BigDecimal amount; // 금액
+    }
+
+    @Data
+    @Builder
+    public static class PersonalExpense {
+        private Long memberId; // 트립 멤버 아이디
+        private String name; // 이름
+        private BigDecimal amount; // 금액
+        private String memberType; // user / shared_fund
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementPageResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementPageResponse.java
@@ -1,0 +1,29 @@
+package com.snapsplit.backend.feature.settlement.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+public class SettlementPageResponse {
+    private TripInfo trip; // 여행 정보
+    private List<SettlementSummary> completeSettlement; // 정산 요약 리스트
+
+    @Data
+    @Builder
+    public static class TripInfo {
+        private LocalDate startDate; // 여행 시작일
+        private LocalDate endDate;   // 여행 종료일
+    }
+
+    @Data
+    @Builder
+    public static class SettlementSummary {
+        private Long id;             // 정산 아이디
+        private LocalDate startDate; // 정산 시작일
+        private LocalDate endDate;   // 정산 종료일
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementRequest.java
@@ -1,0 +1,13 @@
+package com.snapsplit.backend.feature.settlement.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class SettlementRequest {
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementDetailService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementDetailService.java
@@ -1,0 +1,163 @@
+package com.snapsplit.backend.feature.settlement.service;
+
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import com.snapsplit.backend.domain.expense.entity.Pay;
+import com.snapsplit.backend.domain.expense.entity.Split;
+import com.snapsplit.backend.domain.expense.repository.ExpenseRepository;
+import com.snapsplit.backend.domain.expense.repository.PayRepository;
+import com.snapsplit.backend.domain.expense.repository.SplitRepository;
+import com.snapsplit.backend.domain.settlement.entity.Settlement;
+import com.snapsplit.backend.domain.settlement.entity.SettlementDetail;
+import com.snapsplit.backend.domain.settlement.repository.SettlementDetailRepository;
+import com.snapsplit.backend.domain.settlement.repository.SettlementRepository;
+import com.snapsplit.backend.domain.tripmember.entity.MemberType;
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
+import com.snapsplit.backend.feature.settlement.dto.SettlementDetailResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.snapsplit.backend.domain.expense.entity.Pay.MemberType.SHARED_FUND;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementDetailService {
+
+    private final SettlementDetailRepository settlementDetailRepository;
+    private final TripMemberRepository tripMemberRepository;
+    private final SettlementRepository settlementRepository;
+    private final SplitRepository splitRepository;
+    private final ExpenseRepository expenseRepository;
+    private final PayRepository payRepository;
+
+    public SettlementDetailResponse getSettlementDetails(Long tripId, Long settlementId) {
+
+        Settlement settlement = settlementRepository.findById(settlementId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 정산이 존재하지 않습니다."));
+
+        // 정산 상세 내역 조회
+        List<SettlementDetail> details = settlementDetailRepository.findAllBySettlementId(settlementId);
+
+        // TripMember 정보 전체 조회
+        List<TripMember> tripMembers = tripMemberRepository.findAllByTripId(tripId);
+
+        Map<Long, SettlementDetailResponse.Member> memberMap = tripMembers.stream()
+                .collect(Collectors.toMap(
+                        TripMember::getId,
+                        tm -> SettlementDetailResponse.Member.builder()
+                                .memberId(tm.getId())
+                                .name(tm.getMemberType() == MemberType.SHARED_FUND
+                                        ? "공동경비"
+                                        : tm.getUser().getName())
+                                .build()
+                ));
+
+        // 정산 대상 날짜 구간 정의
+        LocalDate from = settlement.getStartDate().minusDays(1); // 시작일 하루 전
+        LocalDate to = settlement.getEndDate(); // 종료일
+
+        // startDate - 1 ~ endDate까지의 유효한 지출 받아오기
+        List<Expense> expenses = expenseRepository.findByTripIdAndExpenseDateBetween(tripId, from, to);
+        List<Long> expenseIds = expenses.stream().map(Expense::getId).toList();
+
+        // expenseId들에 대한 pay 및 split 검색
+        List<Pay> pays = payRepository.findAllByExpenseIdIn(expenseIds);
+        List<Split> splits = splitRepository.findAllByExpenseIdIn(expenseIds);
+
+        // USER별 지출 합계 (split 기준)
+        Map<Long, BigDecimal> personalExpenseMap = splits.stream()
+                .collect(Collectors.groupingBy(
+                        Split::getSplitterId,
+                        Collectors.reducing(BigDecimal.ZERO, Split::getSplitAmountKrw, BigDecimal::add)
+                ));
+
+        // 공동경비 지출 합계 (pay 기준)
+        Map<Long, BigDecimal> sharedFundPayMap = pays.stream()
+                .filter(pay -> pay.getPayer().getMemberType() == MemberType.SHARED_FUND)
+                .collect(Collectors.groupingBy(
+                        pay -> pay.getPayer().getId(),
+                        Collectors.reducing(BigDecimal.ZERO, Pay::getPayAmountKrw, BigDecimal::add)
+                ));
+
+
+        // personalExpenses 생성
+        List<SettlementDetailResponse.PersonalExpense> personalExpenses = tripMembers.stream()
+                .map(tm -> {
+                    BigDecimal amount;
+
+                    if (tm.getMemberType() == MemberType.SHARED_FUND) {
+                        amount = sharedFundPayMap.getOrDefault(tm.getId(), BigDecimal.ZERO);
+                    } else {
+                        amount = personalExpenseMap.getOrDefault(tm.getId(), BigDecimal.ZERO);
+                    }
+
+                    return SettlementDetailResponse.PersonalExpense.builder()
+                            .memberId(tm.getId())
+                            .name(tm.getMemberType() == MemberType.SHARED_FUND
+                                    ? "공동경비"
+                                    : tm.getUser().getName())
+                            .amount(amount)
+                            .memberType(tm.getMemberType().name().toLowerCase()) // "user" 또는 "shared_fund"
+                            .build();
+                }).toList();
+
+        // USER만 추려서 쌍 조합 생성
+        List<TripMember> userMembers = tripMembers.stream()
+                .filter(tm -> tm.getMemberType() == MemberType.USER)
+                .toList();
+
+        // 정산 상세 Map (senderId-receiverId → amount)
+        Map<String, BigDecimal> detailMap = details.stream()
+                .collect(Collectors.toMap(
+                        d -> d.getSender().getId() + "-" + d.getReceiver().getId(),
+                        SettlementDetail::getAmount
+                ));
+
+        // 모든 쌍을 순회하며 amount 채워넣기 (없으면 0으로)
+        List<SettlementDetailResponse.SettlementDetail> detailResponses = new ArrayList<>();
+
+        for (TripMember sender : userMembers) {
+            for (TripMember receiver : userMembers) {
+                if (sender.getId().equals(receiver.getId())) continue;
+
+                BigDecimal amount = detailMap.getOrDefault(
+                        sender.getId() + "-" + receiver.getId(),
+                        BigDecimal.ZERO
+                );
+
+                detailResponses.add(SettlementDetailResponse.SettlementDetail.builder()
+                        .sender(memberMap.get(sender.getId()))
+                        .receiver(memberMap.get(receiver.getId()))
+                        .amount(amount)
+                        .build());
+            }
+        }
+
+        // totalAmount 계산
+        BigDecimal totalAmount = personalExpenses.stream()
+                .map(SettlementDetailResponse.PersonalExpense::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return SettlementDetailResponse.builder()
+                .id(settlementId)
+                .members(
+                        tripMembers.stream()
+                                .filter(tm -> tm.getMemberType() == MemberType.USER)
+                                .map(tm -> memberMap.get(tm.getId()))
+                                .toList()
+                )
+                .settlementDetails(detailResponses)
+                .personalExpenses(personalExpenses)
+                .totalAmount(totalAmount)
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementDetailService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementDetailService.java
@@ -42,6 +42,10 @@ public class SettlementDetailService {
         Settlement settlement = settlementRepository.findById(settlementId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 정산이 존재하지 않습니다."));
 
+        if (!settlement.getTrip().getId().equals(tripId)) {
+            throw new IllegalArgumentException("정산이 해당 여행에 속하지 않습니다.");
+        }
+
         // 정산 상세 내역 조회
         List<SettlementDetail> details = settlementDetailRepository.findAllBySettlementId(settlementId);
 
@@ -102,7 +106,7 @@ public class SettlementDetailService {
                             .memberId(tm.getId())
                             .name(tm.getMemberType() == MemberType.SHARED_FUND
                                     ? "공동경비"
-                                    : tm.getUser().getName())
+                                    : tm.getUser() != null ? tm.getUser().getName() : "Unknown")
                             .amount(amount)
                             .memberType(tm.getMemberType().name().toLowerCase()) // "user" 또는 "shared_fund"
                             .build();

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementPageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementPageService.java
@@ -1,0 +1,43 @@
+package com.snapsplit.backend.feature.settlement.service;
+
+import com.snapsplit.backend.domain.settlement.repository.SettlementRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.feature.settlement.dto.SettlementPageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementPageService {
+
+    private final TripRepository tripRepository;
+    private final SettlementRepository settlementRepository;
+
+    public SettlementPageResponse getSettlementPage(Long tripId) {
+
+        // 여행 찾기
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("여행이 존재하지 않습니다."));
+
+        // 정산 내역 정보
+        List<SettlementPageResponse.SettlementSummary> completeSettlement = settlementRepository.findAllByTripId(tripId).stream()
+                .map(settlement -> SettlementPageResponse.SettlementSummary.builder()
+                        .id(settlement.getId())
+                        .startDate(settlement.getStartDate())
+                        .endDate(settlement.getEndDate())
+                        .build())
+                .toList();
+
+        // 여행 시작일 + 정산 내역 정보 return
+        return SettlementPageResponse.builder()
+                .trip(SettlementPageResponse.TripInfo.builder()
+                        .startDate(trip.getStartDate())
+                        .endDate(trip.getEndDate())
+                        .build())
+                .completeSettlement(completeSettlement)
+                .build();
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementService.java
@@ -61,7 +61,9 @@ public class SettlementService {
 
         for (Pay pay : pays) {
             if (pay.getMemberType() == SHARED_FUND) continue; // 공동경비는 제외
-
+            if (pay.getPayer() == null) {
+                continue;
+            }
             Long memberId = pay.getPayer().getId();
             paidMap.put(memberId,
                     paidMap.getOrDefault(memberId, BigDecimal.ZERO).add(pay.getPayAmountKrw()));

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementService.java
@@ -1,0 +1,166 @@
+package com.snapsplit.backend.feature.settlement.service;
+
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import com.snapsplit.backend.domain.expense.entity.Pay;
+import com.snapsplit.backend.domain.expense.entity.Split;
+import com.snapsplit.backend.domain.expense.repository.ExpenseRepository;
+import com.snapsplit.backend.domain.expense.repository.PayRepository;
+import com.snapsplit.backend.domain.expense.repository.SplitRepository;
+import com.snapsplit.backend.domain.settlement.entity.Settlement;
+import com.snapsplit.backend.domain.settlement.entity.SettlementDetail;
+import com.snapsplit.backend.domain.settlement.repository.SettlementRepository;
+import com.snapsplit.backend.domain.trip.entity.Trip;
+import com.snapsplit.backend.domain.trip.repository.TripRepository;
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
+import com.snapsplit.backend.feature.settlement.dto.SettlementDetailResponse;
+import com.snapsplit.backend.feature.settlement.dto.SettlementRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+
+import static com.snapsplit.backend.domain.expense.entity.Pay.MemberType.SHARED_FUND;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementService {
+
+    private final TripRepository tripRepository;
+    private final TripMemberRepository tripMemberRepository;
+    private final PayRepository payRepository;
+    private final ExpenseRepository expenseRepository;
+    private final SettlementRepository settlementRepository;
+    private final SplitRepository splitRepository;
+
+    public Long createSettlement(Long tripId, SettlementRequest request) {
+
+        // 정산 시작일 및 종료일
+        LocalDate startDate = request.getStartDate();
+        LocalDate endDate = request.getEndDate();
+
+        // 여행 찾기
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 여행입니다."));
+
+        // 정산 대상 멤버 가져오기
+        List<TripMember> tripMembers = tripMemberRepository.findAllByTripId(tripId);
+
+        // startDate - 1 ~ endDate까지의 유효한 지출 받아오기
+        List<Expense> expenses = expenseRepository.findByTripIdAndExpenseDateBetween(tripId, startDate.minusDays(1), endDate);
+        List<Long> expenseIds = expenses.stream().map(Expense::getId).toList();
+
+        // expenseId들에 대한 pay 및 split 검색
+        List<Pay> pays = payRepository.findAllByExpenseIdIn(expenseIds);
+        List<Split> splits = splitRepository.findAllByExpenseIdIn(expenseIds);
+
+        // 각자가 결제한 금액 계산
+        Map<Long, BigDecimal> paidMap = new HashMap<>();
+
+        for (Pay pay : pays) {
+            if (pay.getMemberType() == SHARED_FUND) continue; // 공동경비는 제외
+
+            Long memberId = pay.getPayer().getId();
+            paidMap.put(memberId,
+                    paidMap.getOrDefault(memberId, BigDecimal.ZERO).add(pay.getPayAmountKrw()));
+        }
+
+        // 각자가 쓴 금액 계산
+        Map<Long, BigDecimal> spentMap = new HashMap<>();
+
+        for (Split split : splits) {
+            Long memberId = split.getSplitterId();
+            BigDecimal amount = split.getSplitAmountKrw();
+
+            spentMap.put(memberId,
+                    spentMap.getOrDefault(memberId, BigDecimal.ZERO).add(amount));
+        }
+
+        // netBalance 계산
+        // +인 사람을 받아야 하고, -인 사람은 줘야 함
+        Map<Long, BigDecimal> netBalanceMap = new HashMap<>();
+
+        for (TripMember member : tripMembers) {
+            Long memberId = member.getId();
+
+            BigDecimal paid = paidMap.getOrDefault(memberId, BigDecimal.ZERO);
+            BigDecimal spent = spentMap.getOrDefault(memberId, BigDecimal.ZERO);
+            BigDecimal net = paid.subtract(spent);
+
+            netBalanceMap.put(memberId, net);
+        }
+
+        // 받을 사람, 낼 사람 나누기
+        List<Map.Entry<Long, BigDecimal>> receivers = new ArrayList<>(
+                netBalanceMap.entrySet().stream()
+                        .filter(e -> e.getValue().compareTo(BigDecimal.ZERO) > 0)
+                        .sorted((a, b) -> b.getValue().compareTo(a.getValue()))
+                        .toList()
+        );
+
+        List<Map.Entry<Long, BigDecimal>> payers = new ArrayList<>(
+                netBalanceMap.entrySet().stream()
+                        .filter(e -> e.getValue().compareTo(BigDecimal.ZERO) < 0)
+                        .sorted(Map.Entry.comparingByValue())
+                        .toList()
+        );
+
+
+        // 정산 세부내역 리스트 생성
+        List<SettlementDetail> details = new ArrayList<>();
+
+        int i = 0, j = 0;
+
+        while (i < payers.size() && j < receivers.size()) {
+            var payer = payers.get(i);
+            var receiver = receivers.get(j);
+
+            Long payerId = payer.getKey();
+            Long receiverId = receiver.getKey();
+            BigDecimal payerAmount = payer.getValue().abs(); // -30 → 30
+            BigDecimal receiverAmount = receiver.getValue();
+
+            BigDecimal transfer = payerAmount.min(receiverAmount); // 갚을 수 있는 만큼만
+
+            details.add(SettlementDetail.builder()
+                    .sender(findTripMemberById(tripMembers, payerId))
+                    .receiver(findTripMemberById(tripMembers, receiverId))
+                    .amount(transfer)
+                    .build());
+
+            // 업데이트
+            payers.set(i, Map.entry(payerId, payer.getValue().add(transfer)));
+            receivers.set(j, Map.entry(receiverId, receiverAmount.subtract(transfer)));
+
+            if (payers.get(i).getValue().compareTo(BigDecimal.ZERO) == 0) i++;
+            if (receivers.get(j).getValue().compareTo(BigDecimal.ZERO) == 0) j++;
+        }
+
+        Settlement settlement = Settlement.builder()
+                .trip(trip)
+                .startDate(startDate)
+                .endDate(endDate)
+                .createdAt(LocalDate.now())
+                .build();
+
+        // 양방향 연관관계 설정
+        for (SettlementDetail detail : details) {
+            detail.setSettlement(settlement);
+            settlement.getDetails().add(detail);
+        }
+
+        settlementRepository.save(settlement);
+        return settlement.getId();
+
+    }
+
+    private TripMember findTripMemberById(List<TripMember> members, Long id) {
+        return members.stream()
+                .filter(m -> m.getId().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("TripMember not found: " + id));
+    }
+
+}


### PR DESCRIPTION
### ✨ 개요  
- 정산 영수증 시작 페이지에서 필요로 하는 정산 완료 내역 정보와 여행 시작 정보 조회 기능
- 정산 대상 기간의 지출을 기반으로 정산하는 정산 기능
- 정산 세부 내역 및 정산 기간 동안의 개인 지출, 총 지출 조회 기능

### ✅ 세부 내용  
- tripId를 기반으로 이전 정산 내역을 파악하고, 여행 시작일 및 종료일을 응답하여 정산 영수증 생성 가능일자를 전달함
- 정산 수행 API 구현 (정산 세부 내역 생성 포함)  
- 정산 상세 정보 조회 API 구현  
- settlementDetails, personalExpenses, totalAmount 응답  
- 개인 지출 내역에 공동경비의 지출도 포함(Pay 기반)
- amount가 0인 내역도 포함되도록 처리

### 🔐 관련 API  
- `GET /trips/{tripId}/settlements`  
- `POST /trips/{tripId}/settlements`  
- `GET /trips/{tripId}/settlements?settlementId={n}`  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 정산 기능이 추가되어, 사용자는 여행별로 정산을 생성하고 상세 내역을 조회할 수 있습니다.
  * 정산 페이지에서 여행 기간 및 각 정산 요약 정보를 확인할 수 있습니다.
  * 정산 상세 조회 시, 멤버별 지출 내역과 송금/수취 내역, 총 지출 금액을 확인할 수 있습니다.

* **API 개선**
  * 여행별 정산 생성 및 정산 상세, 정산 페이지 조회를 위한 새로운 REST API 엔드포인트가 추가되었습니다.

* **데이터 조회 기능 강화**
  * 여행, 지출, 결제, 분배, 멤버 등 다양한 조건으로 데이터를 조회할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->