### PR TITLE
[Feat] 정산된 날짜 데이터 처리 - 지출 추가하기

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementRepository.java
@@ -3,8 +3,14 @@ package com.snapsplit.backend.domain.settlement.repository;
 import com.snapsplit.backend.domain.settlement.entity.Settlement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
     List<Settlement> findAllByTripId(Long tripId);
+
+    // trip.id가 tripId이고, startDate <= date <= endDate 인 데이터 존재 여부
+    boolean existsByTrip_IdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+            Long tripId, LocalDate startDate, LocalDate endDate
+    );
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpensePageResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpensePageResponse.java
@@ -12,7 +12,8 @@ public record AddExpensePageResponse(
         List<String> availCurrencies,
         Map<String, BigDecimal> exchangeRates,
         String defaultDate,
-        List<MemberDto> members
+        List<MemberDto> members,
+        List<String> settledDates
 ) {
 
     @Builder

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
@@ -1,11 +1,10 @@
 package com.snapsplit.backend.feature.addExpense.service;
 
-import com.snapsplit.backend.domain.totalshared.entity.TotalShared;
-import com.snapsplit.backend.domain.totalshared.repository.TotalSharedRepository;
+import com.snapsplit.backend.domain.settlement.entity.Settlement;
+import com.snapsplit.backend.domain.settlement.repository.SettlementRepository;
 import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.trip.repository.TripRepository;
 import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository;
-import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.addExpense.dto.AddExpensePageResponse;
 import com.snapsplit.backend.feature.getExchangeRate.dto.ExchangeRateResponse;
@@ -15,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -26,6 +26,7 @@ public class AddExpensePageService {
     private final TripMemberRepository tripMemberRepository;
     private final TripCountryRepository tripCountryRepository;
     private final ExchangeRateService exchangeRateService;
+    private final SettlementRepository settlementRepository;
 
     public AddExpensePageResponse getAddExpensePageData(Long tripId, LocalDate date) {
         Trip trip = tripRepository.findById(tripId)
@@ -58,13 +59,33 @@ public class AddExpensePageService {
                         .build())
                 .toList();
 
-        // 5. 최종 응답 구성
+        // 5. 정산 완료 날짜 오름차순 생성
+        List<Settlement> settlements = settlementRepository.findAllByTripId(tripId);SortedSet<LocalDate> settledSet = new TreeSet<>();
+        for (Settlement s : settlements) {
+            settledSet.addAll(datesBetweenInclusive(s.getStartDate(), s.getEndDate()));
+        }
+
+        List<String> settledDates = settledSet.stream()
+                .map(LocalDate::toString)
+                .toList();
+
+        // 6. 최종 응답 구성
         return AddExpensePageResponse.builder()
                 .defaultCurrency(defaultCurrency)
                 .availCurrencies(availCurrencies)
                 .exchangeRates(exchangeRates)
                 .members(members)
                 .defaultDate(date.toString())
+                .settledDates(settledDates)
                 .build();
+    }
+
+    // [start, end] 포함 범위 날짜 리스트
+    private List<LocalDate> datesBetweenInclusive(LocalDate start, LocalDate end) {
+        if (start == null || end == null || start.isAfter(end)) return List.of();
+        long days = ChronoUnit.DAYS.between(start, end);
+        List<LocalDate> out = new ArrayList<>((int) days + 1);
+        for (long i = 0; i <= days; i++) out.add(start.plusDays(i));
+        return out;
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
@@ -32,6 +32,13 @@ public class AddExpensePageService {
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
 
+        // 정산일 차단: 쿼리 파라미터 date가 정산 구간에 포함되면 에러
+        boolean blocked = settlementRepository
+                .existsByTrip_IdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(tripId, date, date);
+        if (blocked) {
+            throw new IllegalArgumentException("이미 정산된 날짜에는 지출을 추가할 수 없습니다.");
+        }
+
         // 1. 대표 통화
         String defaultCurrency = trip.getDefaultCurrency();
 

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpensePageService.java
@@ -32,10 +32,22 @@ public class AddExpensePageService {
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 여행이 존재하지 않습니다."));
 
-        // 정산일 차단: 쿼리 파라미터 date가 정산 구간에 포함되면 에러
-        boolean blocked = settlementRepository
-                .existsByTrip_IdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(tripId, date, date);
-        if (blocked) {
+        // 여행 기간 밖 접근 차단
+        LocalDate tripStart = trip.getStartDate();
+        LocalDate tripEnd   = trip.getEndDate();
+        LocalDate preTrip   = tripStart.minusDays(1);
+
+        // 여행 시작 전 날짜로 접근시 모두 preTrip로 고정
+        LocalDate effectiveDate = date.isBefore(tripStart) ? preTrip : date;
+        // 여행 종료일 이후면 400에러
+        if (effectiveDate.isAfter(tripEnd)) {
+            throw new IllegalArgumentException(
+                    "여행 기간 밖의 날짜에는 지출을 추가할 수 없습니다.");
+        }
+        // 정규화된 날짜가 정산 구간에 포함되면 400
+        boolean isSettled = settlementRepository
+                .existsByTrip_IdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(tripId, effectiveDate, effectiveDate);
+        if (isSettled) {
             throw new IllegalArgumentException("이미 정산된 날짜에는 지출을 추가할 수 없습니다.");
         }
 
@@ -82,7 +94,7 @@ public class AddExpensePageService {
                 .availCurrencies(availCurrencies)
                 .exchangeRates(exchangeRates)
                 .members(members)
-                .defaultDate(date.toString())
+                .defaultDate(effectiveDate.toString())
                 .settledDates(settledDates)
                 .build();
     }


### PR DESCRIPTION
### ✨ 개요
지출 추가 페이지 기본 데이터 정보 조회 - 정산된 날짜 응답 추가

### ✅ 세부 내용
- 응답에 정산된 날짜 오름차순으로 포함
- 정산된 날짜로 접근시 예외처리
- 여행 기간이 아닌 날짜로 접근시 예외처리
  - 여행 시작일 이전의 날짜 접근 : 모두 여행 준비 지출 등록으로 간주하고 defaultDate를 여행시작일-1일로 응답
 
 ### 🔐 관련 API
- GET /trips/{tripId}/expense/new?date={지출날짜}

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 정산된 날짜 목록이 추가되어, 사용자가 각 여행의 정산된 날짜를 확인할 수 있습니다.

* **버그 수정**
  * 지출 추가 시, 여행 기간 외 날짜에 대한 입력이 더 엄격하게 검증됩니다. 여행 시작 전 날짜는 자동으로 조정되며, 여행 종료 후 날짜는 오류로 처리됩니다.
  * 이미 정산된 기간에 지출을 추가하려고 할 경우 오류가 발생합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->