### PR TITLE
[Feat] 지난 여행 목록  API 확장

### DIFF
--- a/src/main/java/com/snapsplit/backend/feature/home/service/HomeService.java
+++ b/src/main/java/com/snapsplit/backend/feature/home/service/HomeService.java
@@ -23,7 +23,7 @@ public class HomeService {
     // 기본 홈 정보 조회하기
     public HomeResponse getHome(Long userId) {
         // 지난 여행: limit 5
-        List<PastTripResponse> pastTrips = pastTripsService.getPastTrips(userId, 5);
+        List<PastTripResponse> pastTrips = pastTripsService.getPastTripsPreview(userId, 5);
         List<UpcomingTripResponse> upcomingTrips = upcomingTripsService.getUpcomingTrips(userId);
         List<OngoingTripResponse> ongoingTrips = ongoingTripsService.getOngoingTrips(userId);
 

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/controller/PastTripsController.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/controller/PastTripsController.java
@@ -1,18 +1,16 @@
 package com.snapsplit.backend.feature.pastTrips.controller;
 
 import com.snapsplit.backend.feature.pastTrips.dto.PastTripResponse;
+import com.snapsplit.backend.feature.pastTrips.dto.PastTripsResponse;
 import com.snapsplit.backend.feature.pastTrips.service.PastTripsService;
+import com.snapsplit.backend.global.response.ApiResponse;
 import com.snapsplit.backend.global.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Tag(name = "홈", description = "기본 홈/코드로 여행 참여/다가오는 여행/지난 여행")
 @RestController
@@ -23,16 +21,11 @@ public class PastTripsController {
     private final PastTripsService pastTripsService;
 
     @Operation(summary = "과거 여행 목록 조회", description = "사용자가 참여한 과거 여행 목록을 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 실패")
-    })
     @GetMapping("/past")
-    public ResponseEntity<List<PastTripResponse>> getPastTrips(
-            @AuthenticationPrincipal CustomUserPrincipal user,
-            @RequestParam(required = false) Integer limit
-    ) {
-        List<PastTripResponse> trips = pastTripsService.getPastTrips(user.getId(), limit);
-        return ResponseEntity.ok(trips);
+    public ApiResponse<PastTripsResponse> getPastTrips(
+            @AuthenticationPrincipal CustomUserPrincipal user) {
+        PastTripsResponse response = pastTripsService.getPastTripsWithStats(user.getId());
+        return ApiResponse.success("지난 여행 조회 성공", response);
     }
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripsResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripsResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class PastTripsResponse {
-    private List<PastTripResponse> items;
+    private List<PastTripResponse> trips;
     private Integer totalTrips;
     private Integer totalCountries;
 

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripsResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripsResponse.java
@@ -1,0 +1,18 @@
+package com.snapsplit.backend.feature.pastTrips.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PastTripsResponse {
+    private List<PastTripResponse> items;
+    private Integer totalTrips;
+    private Integer totalCountries;
+
+    public static PastTripsResponse of(List<PastTripResponse> items, int totalTrips, int totalCountries) {
+        return new PastTripsResponse(items, totalTrips, totalCountries);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripsResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripsResponse.java
@@ -12,7 +12,7 @@ public class PastTripsResponse {
     private Integer totalTrips;
     private Integer totalCountries;
 
-    public static PastTripsResponse of(List<PastTripResponse> items, int totalTrips, int totalCountries) {
-        return new PastTripsResponse(items, totalTrips, totalCountries);
+    public static PastTripsResponse of(List<PastTripResponse> trips, int totalTrips, int totalCountries) {
+        return new PastTripsResponse(trips, totalTrips, totalCountries);
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/service/PastTripsService.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/service/PastTripsService.java
@@ -4,6 +4,7 @@ import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.tripcountry.repository.TripCountryRepository;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.pastTrips.dto.PastTripResponse;
+import com.snapsplit.backend.feature.pastTrips.dto.PastTripsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,11 +20,10 @@ public class PastTripsService {
     private final TripMemberRepository tripMemberRepository;
     private final TripCountryRepository tripCountryRepository;
 
-    public List<PastTripResponse> getPastTrips(Long userId, Integer limit) {
+    // 기본 홈 지난 여행 미리보기 - limit 적용
+    public List<PastTripResponse> getPastTripsPreview(Long userId, Integer limit) {
         LocalDate today = LocalDate.now();
-
-        // limit이 지정되면 앞에서부터 limit개만 조회, 아니면 전체 조회
-        Pageable pageable = (limit != null) ? PageRequest.of(0, limit) : Pageable.unpaged();
+        var pageable = PageRequest.of(0, limit);
 
         // TripMember를 통해 userId가 참여한 Trip 중, 지난 여행(endDate < today)만 조회함
         List<Trip> trips = tripMemberRepository.findPastTripsByUserId(userId, today, pageable);
@@ -34,10 +33,33 @@ public class PastTripsService {
                     // Trip → TripCountry → Country 연관관계를 따라 국가 이름 목록 추출
                     List<String> countryNames = tripCountryRepository.findAllByTripId(trip.getId()).stream()
                             .map(tc -> tc.getCountry().getCountryName())
-                            .collect(Collectors.toList());
-
+                            .toList();
                     return PastTripResponse.from(trip, countryNames);
                 })
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    // 지난 여행 전체보기 - 전체 여행 수, 여행 국가 수 포함 envelope 반환
+    public PastTripsResponse getPastTripsWithStats(Long userId) {
+        LocalDate today = LocalDate.now();
+        // 전체 조회
+        List<Trip> trips = tripMemberRepository.findPastTripsByUserId(userId, today, Pageable.unpaged());
+
+        List<PastTripResponse> items = trips.stream()
+                .map(trip -> {
+                    List<String> countryNames = tripCountryRepository.findAllByTripId(trip.getId()).stream()
+                            .map(tc -> tc.getCountry().getCountryName())
+                            .toList();
+                    return PastTripResponse.from(trip, countryNames);
+                })
+                .toList();
+
+        int totalTrips = items.size();
+        int totalCountries = items.stream()
+                .flatMap(t -> t.getCountryNames().stream())
+                .collect(java.util.stream.Collectors.toSet())
+                .size();
+
+        return PastTripsResponse.of(items, totalTrips, totalCountries);
     }
 }


### PR DESCRIPTION
### ✨ 개요
- 지난 여행 목록 API 확장

### ✅ 세부 내용
- 'PastTripsResponse' DTO 추가: 'totalTrips', 'totalCountries', 'trips' 필드 포함
- 기본홈 - pastTrips는 최신순으로 5개로 잘라서 preview
- 지난 여행 목록 - 모든 pastTrips를 최신순으로 보여줌

### 🔐 관련 API
- GET /trips/past
- GET /home

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영됨
- 기존 기능 영향 최소화를 위해 홈 조회 로직은 preview 형태로 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지난 여행 목록 조회 시 전체 여행 수와 방문한 국가 수를 함께 확인할 수 있도록 응답 구조가 개선되었습니다.

* **기능 개선**
  * 지난 여행 조회 API의 응답 형식이 리스트에서 요약 정보(총 여행 수, 총 국가 수)와 함께 제공되는 구조로 변경되었습니다.
  * 지난 여행 조회 시 요청 파라미터가 단순화되어 limit 파라미터 없이 전체 여행 정보를 받아볼 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->