### PR TITLE
[Feat] 정산 영수증 개별 지출 상세 금액 조회

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/PayRepository.java
@@ -22,4 +22,7 @@ public interface PayRepository extends JpaRepository<Pay, Long> {
 
     // 여러 개의 expenseId에 대해서 Pay 검색
     List<Pay> findAllByExpenseIdIn(List<Long> expenseIds);
+
+    // payId와 여러 expenseId에 대한 pay 내역 찾기
+    List<Pay> findAllByExpenseIdInAndPayerId(List<Long> expenseIds, Long payerId);
 }

--- a/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/repository/SplitRepository.java
@@ -19,4 +19,7 @@ public interface SplitRepository extends JpaRepository<Split, Long> {
 
     // 여러 개의 expenseId에 대해 Split 검색
     List<Split> findAllByExpenseIdIn(List<Long> expenseIds);
+
+    // splitterId와 여러 expenseId에 대한 split 내역 찾기
+    List<Split> findAllByExpenseIdInAndSplitterId(List<Long> expenseIds, Long splitterId);
 }

--- a/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementController.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementController.java
@@ -3,6 +3,7 @@ package com.snapsplit.backend.feature.settlement.controller;
 import com.snapsplit.backend.feature.settlement.dto.SettlementCreationResponse;
 import com.snapsplit.backend.feature.settlement.dto.SettlementRequest;
 import com.snapsplit.backend.feature.settlement.service.SettlementDetailService;
+import com.snapsplit.backend.feature.settlement.service.SettlementExpenseService;
 import com.snapsplit.backend.feature.settlement.service.SettlementService;
 import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
@@ -19,6 +20,7 @@ public class SettlementController {
 
     private final SettlementService settlementService;
     private final SettlementDetailService settlementDetailService;
+    private final SettlementExpenseService settlementExpenseService;
 
     @Operation(summary = "정산하기", description = "정산 시작일 및 종료일을 기반으로 정산을 처리합니다.")
     @PostMapping("/{tripId}/settlements")
@@ -41,6 +43,18 @@ public class SettlementController {
         return ApiResponse.success(
                 "정산 상세 내역 조회 성공",
                 settlementDetailService.getSettlementDetails(tripId, settlementId)
+        );
+    }
+
+    @Operation(summary = "정산 영수증 개별 지출 상세 금액 조회", description = "여행 멤버 ID를 기반으로 정산 내역 상세 조회에서 개별 지출에 대한 세부 정보를 조회합니다.")
+    @GetMapping(value = "/trips/{tripId}/settlement", params = {"settlementId", "memberId"})
+    @CheckTripMember
+    public ApiResponse<?> getSettlementExpense(@PathVariable Long tripId,
+                                               @RequestParam Long settlementId,
+                                               @RequestParam Long memberId) {
+        return ApiResponse.success(
+                "정산 영수증 개별 지출 상세 금액 조회 성공",
+                settlementExpenseService.getSettlementExpense(tripId, settlementId, memberId)
         );
     }
 

--- a/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementController.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/controller/SettlementController.java
@@ -1,6 +1,8 @@
 package com.snapsplit.backend.feature.settlement.controller;
 
 import com.snapsplit.backend.feature.settlement.dto.SettlementCreationResponse;
+import com.snapsplit.backend.feature.settlement.dto.SettlementDetailResponse;
+import com.snapsplit.backend.feature.settlement.dto.SettlementExpenseResponse;
 import com.snapsplit.backend.feature.settlement.dto.SettlementRequest;
 import com.snapsplit.backend.feature.settlement.service.SettlementDetailService;
 import com.snapsplit.backend.feature.settlement.service.SettlementExpenseService;
@@ -38,8 +40,8 @@ public class SettlementController {
     @Operation(summary = "정산 영수증 상세 조회", description = "정산 ID를 기반으로 정산 상세 내역을 조회합니다.")
     @GetMapping("/{tripId}/settlement")
     @CheckTripMember
-    public ApiResponse<?> getSettlementDetails(@PathVariable Long tripId,
-                                               @RequestParam Long settlementId) {
+    public ApiResponse<SettlementDetailResponse> getSettlementDetails(@PathVariable Long tripId,
+                                                                      @RequestParam Long settlementId) {
         return ApiResponse.success(
                 "정산 상세 내역 조회 성공",
                 settlementDetailService.getSettlementDetails(tripId, settlementId)
@@ -47,11 +49,11 @@ public class SettlementController {
     }
 
     @Operation(summary = "정산 영수증 개별 지출 상세 금액 조회", description = "여행 멤버 ID를 기반으로 정산 내역 상세 조회에서 개별 지출에 대한 세부 정보를 조회합니다.")
-    @GetMapping(value = "/trips/{tripId}/settlement", params = {"settlementId", "memberId"})
+    @GetMapping(value = "/{tripId}/settlement/expenses")
     @CheckTripMember
-    public ApiResponse<?> getSettlementExpense(@PathVariable Long tripId,
-                                               @RequestParam Long settlementId,
-                                               @RequestParam Long memberId) {
+    public ApiResponse<SettlementExpenseResponse> getSettlementExpense(@PathVariable Long tripId,
+                                                                       @RequestParam Long settlementId,
+                                                                       @RequestParam Long memberId) {
         return ApiResponse.success(
                 "정산 영수증 개별 지출 상세 금액 조회 성공",
                 settlementExpenseService.getSettlementExpense(tripId, settlementId, memberId)

--- a/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementExpenseResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementExpenseResponse.java
@@ -1,0 +1,32 @@
+package com.snapsplit.backend.feature.settlement.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@Builder
+public class SettlementExpenseResponse {
+
+    private List<SettlementDetailByMember> settlementDetailsByMember;
+    private BigDecimal totalKRW; // 총 지출액
+
+    @Data
+    @Builder
+    public static class SettlementDetailByMember {
+        private String date; // 날짜
+        private List<ExpenseItem> items; // 지출 상세내역
+    }
+
+    @Data
+    @Builder
+    public static class ExpenseItem {
+        private String expenseName; // 지출명
+        private String expenseMemo; // 지출상세
+        private BigDecimal amount; // 지출액
+        private BigDecimal amountKRW; // 한화 지출액
+        private String expenseCurrency; // 통화
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementPageResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementPageResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 public class SettlementPageResponse {
     private TripInfo trip; // 여행 정보
     private List<SettlementSummary> completeSettlement; // 정산 요약 리스트
+    private List<DailyExpenseStatus> dailyExpenseStatus; // 여행일자별 지출 유무
 
     @Data
     @Builder
@@ -25,5 +26,12 @@ public class SettlementPageResponse {
         private Long id;             // 정산 아이디
         private LocalDate startDate; // 정산 시작일
         private LocalDate endDate;   // 정산 종료일
+    }
+
+    @Data
+    @Builder
+    public static class DailyExpenseStatus {
+        private LocalDate date;      // 날짜
+        private boolean hasExpense;  // 해당 날짜 지출 유무
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementExpenseService.java
@@ -1,0 +1,102 @@
+package com.snapsplit.backend.feature.settlement.service;
+
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import com.snapsplit.backend.domain.expense.entity.Split;
+import com.snapsplit.backend.domain.expense.repository.ExpenseRepository;
+import com.snapsplit.backend.domain.expense.repository.SplitRepository;
+import com.snapsplit.backend.domain.settlement.entity.Settlement;
+import com.snapsplit.backend.domain.settlement.repository.SettlementRepository;
+import com.snapsplit.backend.feature.settlement.dto.SettlementExpenseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementExpenseService {
+
+    private final SettlementRepository settlementRepository;
+    private final ExpenseRepository expenseRepository;
+    private final SplitRepository splitRepository;
+
+    public SettlementExpenseResponse getSettlementExpense(Long tripId, Long settlementId, Long memberId) {
+        Settlement settlement = settlementRepository.findById(settlementId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 정산이 존재하지 않습니다."));
+
+        if (!settlement.getTrip().getId().equals(tripId)) {
+            throw new IllegalArgumentException("정산이 해당 여행에 속하지 않습니다.");
+        }
+
+        // 정산 대상 날짜 구간 정의
+        LocalDate from = settlement.getStartDate().minusDays(1); // 시작일 하루 전
+        LocalDate to = settlement.getEndDate(); // 종료일
+
+        // 정산 기간에 대한 지출들 받아오기
+        List<Expense> expenses = expenseRepository.findByTripIdAndExpenseDateBetween(tripId, from, to);
+        if (expenses.isEmpty()) {
+            return SettlementExpenseResponse.builder()
+                    .settlementDetailsByMember(List.of())
+                    .totalKRW(BigDecimal.ZERO)
+                    .build();
+        }
+
+        // expenses 리스트를 expenseId -> Expense 객체로 바로 찾을 수 있도록 Map 구조로 바꾸기
+        Map<Long, Expense> expenseMap = expenses.stream()
+                .collect(Collectors.toMap(Expense::getId, e -> e));
+
+        List<Long> expenseIds = expenses.stream().map(Expense::getId).toList();
+
+        // expenseId들과 memberId로 split 내역 찾기
+        List<Split> splits = splitRepository.findAllByExpenseIdInAndSplitterId(expenseIds, memberId);
+        if (splits.isEmpty()) {
+            return SettlementExpenseResponse.builder()
+                    .settlementDetailsByMember(List.of())
+                    .totalKRW(BigDecimal.ZERO)
+                    .build();
+        }
+
+        Map<LocalDate, List<SettlementExpenseResponse.ExpenseItem>> byDate = new HashMap<>();
+
+        for (Split s : splits) {
+            Expense ex = expenseMap.get(s.getExpenseId());
+            if (ex == null) continue;
+
+            BigDecimal amt = s.getSplitAmount();
+            BigDecimal amtKrw = s.getSplitAmountKrw();
+
+            SettlementExpenseResponse.ExpenseItem item = SettlementExpenseResponse.ExpenseItem.builder()
+                    .expenseName(Optional.ofNullable(ex.getExpenseName()).orElse(""))
+                    .expenseMemo(Optional.ofNullable(ex.getExpenseMemo()).orElse(""))
+                    .amount(amt)
+                    .amountKRW(amtKrw)
+                    .expenseCurrency(ex.getExpenseCurrency())
+                    .build();
+
+            byDate.computeIfAbsent(ex.getExpenseDate(), k -> new ArrayList<>()).add(item);
+        }
+
+        List<SettlementExpenseResponse.SettlementDetailByMember> details = byDate.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> SettlementExpenseResponse.SettlementDetailByMember.builder()
+                        .date(e.getKey().toString())
+                        .items(e.getValue())
+                        .build())
+                .toList();
+
+        BigDecimal totalKRW = byDate.values().stream()
+                .flatMap(List::stream)
+                .map(SettlementExpenseResponse.ExpenseItem::getAmountKRW)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return SettlementExpenseResponse.builder()
+                .settlementDetailsByMember(details)
+                .totalKRW(totalKRW)
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementExpenseService.java
@@ -126,7 +126,7 @@ public class SettlementExpenseService {
 
         BigDecimal totalKRW = byDate.values().stream()
                 .flatMap(List::stream)
-                .map(SettlementExpenseResponse.ExpenseItem::getAmountKRW)
+                .map(i -> Optional.ofNullable(i.getAmountKRW()).orElse(BigDecimal.ZERO))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         return SettlementExpenseResponse.builder()

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementExpenseService.java
@@ -1,12 +1,18 @@
 package com.snapsplit.backend.feature.settlement.service;
 
 import com.snapsplit.backend.domain.expense.entity.Expense;
+import com.snapsplit.backend.domain.expense.entity.Pay;
 import com.snapsplit.backend.domain.expense.entity.Split;
 import com.snapsplit.backend.domain.expense.repository.ExpenseRepository;
+import com.snapsplit.backend.domain.expense.repository.PayRepository;
 import com.snapsplit.backend.domain.expense.repository.SplitRepository;
 import com.snapsplit.backend.domain.settlement.entity.Settlement;
 import com.snapsplit.backend.domain.settlement.repository.SettlementRepository;
+import com.snapsplit.backend.domain.tripmember.entity.MemberType;
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.feature.settlement.dto.SettlementExpenseResponse;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +28,10 @@ public class SettlementExpenseService {
     private final SettlementRepository settlementRepository;
     private final ExpenseRepository expenseRepository;
     private final SplitRepository splitRepository;
+    private final PayRepository payRepository;
+    private final TripMemberRepository tripMemberRepository;
 
+    @Transactional(readOnly = true)
     public SettlementExpenseResponse getSettlementExpense(Long tripId, Long settlementId, Long memberId) {
         Settlement settlement = settlementRepository.findById(settlementId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 정산이 존재하지 않습니다."));
@@ -31,12 +40,17 @@ public class SettlementExpenseService {
             throw new IllegalArgumentException("정산이 해당 여행에 속하지 않습니다.");
         }
 
+        TripMember member = tripMemberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("여행 멤버가 존재하지 않습니다."));
+
+
         // 정산 대상 날짜 구간 정의
         LocalDate from = settlement.getStartDate().minusDays(1); // 시작일 하루 전
         LocalDate to = settlement.getEndDate(); // 종료일
 
         // 정산 기간에 대한 지출들 받아오기
         List<Expense> expenses = expenseRepository.findByTripIdAndExpenseDateBetween(tripId, from, to);
+
         if (expenses.isEmpty()) {
             return SettlementExpenseResponse.builder()
                     .settlementDetailsByMember(List.of())
@@ -47,36 +61,59 @@ public class SettlementExpenseService {
         // expenses 리스트를 expenseId -> Expense 객체로 바로 찾을 수 있도록 Map 구조로 바꾸기
         Map<Long, Expense> expenseMap = expenses.stream()
                 .collect(Collectors.toMap(Expense::getId, e -> e));
-
         List<Long> expenseIds = expenses.stream().map(Expense::getId).toList();
-
-        // expenseId들과 memberId로 split 내역 찾기
-        List<Split> splits = splitRepository.findAllByExpenseIdInAndSplitterId(expenseIds, memberId);
-        if (splits.isEmpty()) {
-            return SettlementExpenseResponse.builder()
-                    .settlementDetailsByMember(List.of())
-                    .totalKRW(BigDecimal.ZERO)
-                    .build();
-        }
 
         Map<LocalDate, List<SettlementExpenseResponse.ExpenseItem>> byDate = new HashMap<>();
 
-        for (Split s : splits) {
-            Expense ex = expenseMap.get(s.getExpenseId());
-            if (ex == null) continue;
+        if (member.getMemberType() == MemberType.SHARED_FUND) {
+            // 공동경비 멤버: Split이 아니라 Pay에서 조회
+            List<Pay> pays = payRepository.findAllByExpenseIdInAndPayerId(expenseIds, memberId);
+            if (pays.isEmpty()) {
+                return SettlementExpenseResponse.builder()
+                        .settlementDetailsByMember(List.of())
+                        .totalKRW(BigDecimal.ZERO)
+                        .build();
+            }
 
-            BigDecimal amt = s.getSplitAmount();
-            BigDecimal amtKrw = s.getSplitAmountKrw();
+            for (Pay p : pays) {
+                Expense ex = expenseMap.get(p.getExpenseId());
+                if (ex == null) continue;
 
-            SettlementExpenseResponse.ExpenseItem item = SettlementExpenseResponse.ExpenseItem.builder()
-                    .expenseName(Optional.ofNullable(ex.getExpenseName()).orElse(""))
-                    .expenseMemo(Optional.ofNullable(ex.getExpenseMemo()).orElse(""))
-                    .amount(amt)
-                    .amountKRW(amtKrw)
-                    .expenseCurrency(ex.getExpenseCurrency())
-                    .build();
+                SettlementExpenseResponse.ExpenseItem item = SettlementExpenseResponse.ExpenseItem.builder()
+                        .expenseName(Optional.ofNullable(ex.getExpenseName()).orElse(""))
+                        .expenseMemo(Optional.ofNullable(ex.getExpenseMemo()).orElse(""))
+                        .amount(p.getPayAmount())            // 부호 정책: 현재 그대로 노출
+                        .amountKRW(p.getPayAmountKrw())      // 필요시 .negate()로 변경 가능
+                        .expenseCurrency(ex.getExpenseCurrency())
+                        .build();
 
-            byDate.computeIfAbsent(ex.getExpenseDate(), k -> new ArrayList<>()).add(item);
+                byDate.computeIfAbsent(ex.getExpenseDate(), k -> new ArrayList<>()).add(item);
+            }
+
+        } else {
+            // 일반 멤버: Split에서 조회
+            List<Split> splits = splitRepository.findAllByExpenseIdInAndSplitterId(expenseIds, memberId);
+            if (splits.isEmpty()) {
+                return SettlementExpenseResponse.builder()
+                        .settlementDetailsByMember(List.of())
+                        .totalKRW(BigDecimal.ZERO)
+                        .build();
+            }
+
+            for (Split s : splits) {
+                Expense ex = expenseMap.get(s.getExpenseId());
+                if (ex == null) continue;
+
+                SettlementExpenseResponse.ExpenseItem item = SettlementExpenseResponse.ExpenseItem.builder()
+                        .expenseName(Optional.ofNullable(ex.getExpenseName()).orElse(""))
+                        .expenseMemo(Optional.ofNullable(ex.getExpenseMemo()).orElse(""))
+                        .amount(s.getSplitAmount())          // 부호 정책: 현재 그대로 노출
+                        .amountKRW(s.getSplitAmountKrw())    // 필요시 .negate()로 변경 가능
+                        .expenseCurrency(ex.getExpenseCurrency())
+                        .build();
+
+                byDate.computeIfAbsent(ex.getExpenseDate(), k -> new ArrayList<>()).add(item);
+            }
         }
 
         List<SettlementExpenseResponse.SettlementDetailByMember> details = byDate.entrySet().stream()

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementExpenseService.java
@@ -63,7 +63,7 @@ public class SettlementExpenseService {
                 .collect(Collectors.toMap(Expense::getId, e -> e));
         List<Long> expenseIds = expenses.stream().map(Expense::getId).toList();
 
-        Map<LocalDate, List<SettlementExpenseResponse.ExpenseItem>> byDate = new HashMap<>();
+        Map<LocalDate, List<SettlementExpenseResponse.ExpenseItem>> byDate = new TreeMap<>();
 
         if (member.getMemberType() == MemberType.SHARED_FUND) {
             // 공동경비 멤버: Split이 아니라 Pay에서 조회
@@ -82,8 +82,8 @@ public class SettlementExpenseService {
                 SettlementExpenseResponse.ExpenseItem item = SettlementExpenseResponse.ExpenseItem.builder()
                         .expenseName(Optional.ofNullable(ex.getExpenseName()).orElse(""))
                         .expenseMemo(Optional.ofNullable(ex.getExpenseMemo()).orElse(""))
-                        .amount(p.getPayAmount())            // 부호 정책: 현재 그대로 노출
-                        .amountKRW(p.getPayAmountKrw())      // 필요시 .negate()로 변경 가능
+                        .amount(Optional.ofNullable(p.getPayAmount()).orElse(BigDecimal.ZERO))            // 부호 정책: 현재 그대로 노출
+                        .amountKRW(Optional.ofNullable(p.getPayAmountKrw()).orElse(BigDecimal.ZERO))      // 필요시 .negate()로 변경 가능
                         .expenseCurrency(ex.getExpenseCurrency())
                         .build();
 
@@ -107,8 +107,8 @@ public class SettlementExpenseService {
                 SettlementExpenseResponse.ExpenseItem item = SettlementExpenseResponse.ExpenseItem.builder()
                         .expenseName(Optional.ofNullable(ex.getExpenseName()).orElse(""))
                         .expenseMemo(Optional.ofNullable(ex.getExpenseMemo()).orElse(""))
-                        .amount(s.getSplitAmount())          // 부호 정책: 현재 그대로 노출
-                        .amountKRW(s.getSplitAmountKrw())    // 필요시 .negate()로 변경 가능
+                        .amount(Optional.ofNullable(s.getSplitAmount()).orElse(BigDecimal.ZERO))          // 부호 정책: 현재 그대로 노출
+                        .amountKRW(Optional.ofNullable(s.getSplitAmountKrw()).orElse(BigDecimal.ZERO))    // 필요시 .negate()로 변경 가능
                         .expenseCurrency(ex.getExpenseCurrency())
                         .build();
 

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementPageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementPageService.java
@@ -1,5 +1,7 @@
 package com.snapsplit.backend.feature.settlement.service;
 
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import com.snapsplit.backend.domain.expense.repository.ExpenseRepository;
 import com.snapsplit.backend.domain.settlement.repository.SettlementRepository;
 import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.trip.repository.TripRepository;
@@ -7,7 +9,11 @@ import com.snapsplit.backend.feature.settlement.dto.SettlementPageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +21,7 @@ public class SettlementPageService {
 
     private final TripRepository tripRepository;
     private final SettlementRepository settlementRepository;
+    private final ExpenseRepository expenseRepository;
 
     public SettlementPageResponse getSettlementPage(Long tripId) {
 
@@ -31,6 +38,28 @@ public class SettlementPageService {
                         .build())
                 .toList();
 
+        // 여행 기간 내 모든 지출 날짜 세트화
+        LocalDate start = trip.getStartDate().minusDays(1);
+        LocalDate end = trip.getEndDate();
+
+        List<Expense> expensesInRange =
+                expenseRepository.findByTripIdAndExpenseDateBetween(tripId, start, end);
+
+        Set<LocalDate> expenseDates = expensesInRange.stream()
+                .map(Expense::getExpenseDate)
+                .collect(Collectors.toSet());
+
+        // 날짜별 지출 유무 리스트 생성
+        List<SettlementPageResponse.DailyExpenseStatus> dailyExpenseStatus = new ArrayList<>();
+        for (LocalDate d = start; !d.isAfter(end); d = d.plusDays(1)) {
+            dailyExpenseStatus.add(
+                    SettlementPageResponse.DailyExpenseStatus.builder()
+                            .date(d)
+                            .hasExpense(expenseDates.contains(d))
+                            .build()
+            );
+        }
+
         // 여행 시작일 + 정산 내역 정보 return
         return SettlementPageResponse.builder()
                 .trip(SettlementPageResponse.TripInfo.builder()
@@ -38,6 +67,7 @@ public class SettlementPageService {
                         .endDate(trip.getEndDate())
                         .build())
                 .completeSettlement(completeSettlement)
+                .dailyExpenseStatus(dailyExpenseStatus)
                 .build();
     }
 }


### PR DESCRIPTION
### ✨ 개요
완료된 정산(`settlementId`) 기준으로 특정 멤버(`memberId`)의 날짜별 개별 지출 내역과 총액(KRW)을 조회

### ✅ 세부 내용
- 정산/여행 검증 : `settlementId`로 정산 조회, 해당 정산이 `tripId`에 속하는지 검증 (불일치 시 400)
- 데이터 수집 구간
  - 정산 기간: `startDate - 1`(여행 준비일) ~ `endDate`
  - 위 구간에서 `Expense` 일괄 조회 → `expenseId` 목록 생성
  - `Split`에서 `splitterId == memberId` & `expenseId IN (...)` 조건으로 필터 조회
 - `expenses`를 `Map<Long, Expense>`로 캐싱하여 `Split` 매칭 시 메모리 접근 (추가 쿼리 방지)
- 응답 생성
  - 날짜별 그룹핑(오름차순)
  - 항목 필드: `expenseName`, `expenseMemo`, `amount`, `amountKRW`, `expenseCurrency`, `amount`, `amountKRW`
  - 전체 합계 `totalKRW` 계산
- 정산 영수증 시작 페이지에 여행 일자별 지출 유무를 추가로 보내도록 수정함

### 🔐 관련 API
- GET `/trips/{tripId}/settlement?settlementId={n}&memberId={n}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 정산 상세 내역을 멤버별로 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 정산 상세 내역 응답에 날짜별 지출 항목과 총 금액(KRW 기준)이 포함됩니다.
  * 정산 페이지 응답에 여행 기간 내 날짜별 지출 발생 여부를 확인할 수 있는 정보가 추가되었습니다.
  * 특정 멤버와 관련된 지출 및 결제 내역을 조회하는 기능이 향상되었습니다.

* **버그 수정**
  * 해당 없음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->