### PR TITLE
[Refactor] Enum 타입 대문자로 통일

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/shared/entity/PaymentMethod.java
+++ b/src/main/java/com/snapsplit/backend/domain/shared/entity/PaymentMethod.java
@@ -2,6 +2,6 @@ package com.snapsplit.backend.domain.shared.entity;
 
 // 지불 방식
 public enum PaymentMethod {
-    cash, // 현금
-    credit_card // 신용카드
+    CASH, // 현금
+    CREDIT_CARD // 신용카드
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -216,7 +216,7 @@ public class AddExpenseService {
                 .amount(expense.getExpenseAmount())
                 .amountKRW(expense.getExpenseKrw())
                 .currency(expense.getExpenseCurrency())
-                .paymentMethod(expense.getPaymentMethod().toString().toLowerCase())
+                .paymentMethod(expense.getPaymentMethod().toString())
                 .date(expense.getExpenseDate())
                 .expenseName(expense.getExpenseName())
                 .expenseMemo(expense.getExpenseMemo())
@@ -281,7 +281,7 @@ public class AddExpenseService {
 
     private PaymentMethod parsePaymentMethod(String value) {
         try {
-            return PaymentMethod.valueOf(value.trim().toLowerCase());
+            return PaymentMethod.valueOf(value.trim());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("유효하지 않은 결제 방식입니다: " + value);
         }

--- a/src/main/java/com/snapsplit/backend/feature/getSharedDetails/service/GetSharedDetailsService.java
+++ b/src/main/java/com/snapsplit/backend/feature/getSharedDetails/service/GetSharedDetailsService.java
@@ -1,9 +1,7 @@
 package com.snapsplit.backend.feature.getSharedDetails.service;
 
 import com.snapsplit.backend.domain.expense.entity.Expense;
-import com.snapsplit.backend.domain.expense.entity.Pay;
 import com.snapsplit.backend.domain.expense.repository.ExpenseRepository;
-import com.snapsplit.backend.domain.expense.repository.PayRepository;
 import com.snapsplit.backend.domain.shared.entity.Shared;
 import com.snapsplit.backend.domain.shared.entity.SharedType;
 import com.snapsplit.backend.domain.shared.repository.SharedRepository;
@@ -20,11 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static com.snapsplit.backend.domain.shared.entity.SharedType.WITHDRAW;
 
 @Service
 @RequiredArgsConstructor
@@ -53,7 +48,7 @@ public class GetSharedDetailsService {
                         s -> s.getCreatedAt().toString(), // 여기 s 선언됨
                         LinkedHashMap::new,
                         Collectors.mapping(s -> {
-                            String type = s.getSharedType().name().toLowerCase();
+                            String type = s.getSharedType().name();
                             String title = null;
                             String memo = null;
                             BigDecimal amount = s.getAmount();
@@ -64,25 +59,25 @@ public class GetSharedDetailsService {
                                 Expense e = expenseRepository.findById(s.getExpenseId())
                                         .orElse(null);
                                 if (e != null) {
-                                    type = SharedType.EXPENSE.name().toLowerCase();
+                                    type = SharedType.EXPENSE.name();
                                     title = e.getExpenseName();
                                     memo = e.getExpenseMemo();
                                 } else {
                                     // expense를 찾을 수 없는 경우
-                                    type = SharedType.EXPENSE.name().toLowerCase();
+                                    type = SharedType.EXPENSE.name();
                                     title = "알 수 없는 지출";
                                     memo = "";
                                 }
                             } else {
                                 // DEPOSIT인 경우
                                 if(s.getSharedType() == SharedType.DEPOSIT) {
-                                    type = SharedType.DEPOSIT.name().toLowerCase();
+                                    type = SharedType.DEPOSIT.name();
                                     title = "공동경비 입금";
                                     memo = "";
                                 }
                                 // WITHDRAW인 경우
                                 else if(s.getSharedType() == SharedType.WITHDRAW) {
-                                    type = SharedType.WITHDRAW.name().toLowerCase();
+                                    type = SharedType.WITHDRAW.name();
                                     title = "공동경비 출금";
                                     memo = "";
                                 }

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementDetailService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementDetailService.java
@@ -108,7 +108,7 @@ public class SettlementDetailService {
                                     ? "공동경비"
                                     : tm.getUser() != null ? tm.getUser().getName() : "Unknown")
                             .amount(amount)
-                            .memberType(tm.getMemberType().name().toLowerCase()) // "user" 또는 "shared_fund"
+                            .memberType(tm.getMemberType().name()) // "user" 또는 "shared_fund"
                             .build();
                 }).toList();
 


### PR DESCRIPTION
### ✨ 개요
- 기존 Enum 타입 소문자로 인식 또는 응답한 부분들 대문자로 통일

### 세부 내용
- `Shared `테이블 `payment` Enum 타입 대문자 변경
- 기타 `toLowerCase()`로 변형되던 부분 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 결제수단, 공유 유형, 멤버 유형 등 여러 항목의 문자열 표기에서 기존의 소문자 표기 대신 대문자 표기로 변경되었습니다.  
  * 일부 불필요한 임포트가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->