### PR TITLE
[Feat] 영수증 파싱 및 지출 연동 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    implementation platform("com.google.cloud:libraries-bom:26.49.0")
+    implementation "com.google.cloud:google-cloud-document-ai"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/snapsplit/backend/config/DocAiConfig.java
+++ b/src/main/java/com/snapsplit/backend/config/DocAiConfig.java
@@ -1,0 +1,54 @@
+package com.snapsplit.backend.config;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.documentai.v1.DocumentProcessorServiceClient;
+import com.google.cloud.documentai.v1.DocumentProcessorServiceSettings;
+import com.google.cloud.documentai.v1.ProcessorName;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.util.List;
+
+@Configuration
+public class DocAiConfig {
+
+    @Value("${gcp.docai.credentials-path}")
+    private String credentialsPath;
+
+    @Value("${gcp.docai.project-id}")
+    private String projectId;
+
+    @Value("${gcp.docai.location}")
+    private String location;
+
+    @Value("${gcp.docai.processor-id}")
+    private String processorId;
+
+    @Bean
+    public DocumentProcessorServiceClient documentProcessorServiceClient() throws Exception {
+        // 1) 자격 증명 로드 + 스코프 강제
+        GoogleCredentials creds;
+        try (FileInputStream fis = new FileInputStream(credentialsPath)) {
+            creds = GoogleCredentials.fromStream(fis)
+                    .createScoped(DocumentProcessorServiceSettings.getDefaultServiceScopes());
+        }
+
+        // 2) 리전 엔드포인트 고정 (us/eu/asia)
+        DocumentProcessorServiceSettings settings = DocumentProcessorServiceSettings.newBuilder()
+                .setEndpoint(String.format("%s-documentai.googleapis.com:443", location))
+                .setCredentialsProvider(FixedCredentialsProvider.create(creds))
+                .build();
+
+        // 3) 디버그 로그 (실행 후 콘솔에서 필히 확인)
+        String procName = ProcessorName.of(projectId, location, processorId).toString();
+        System.out.println("[DOC-AI] credentials-path = " + credentialsPath);
+        System.out.println("[DOC-AI] processor = " + procName);
+        System.out.println("[DOC-AI] endpoint  = " + settings.getEndpoint());
+        // client email은 creds에서 직접 노출 메서드가 없어 키 JSON 파일명으로만 추정됨 (보안상 노출 지양)
+
+        return DocumentProcessorServiceClient.create(settings);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/domain/expense/entity/Expense.java
+++ b/src/main/java/com/snapsplit/backend/domain/expense/entity/Expense.java
@@ -1,5 +1,6 @@
 package com.snapsplit.backend.domain.expense.entity;
 
+import com.snapsplit.backend.domain.receipt.entity.Receipt;
 import jakarta.persistence.*;
 import lombok.*;
 import java.math.BigDecimal;
@@ -46,6 +47,9 @@ public class Expense {
     @Enumerated(EnumType.STRING)
     @Column(name = "payment_method", nullable = false)
     private PaymentMethod paymentMethod;
+
+    @OneToOne(mappedBy = "expense", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Receipt receipt;
 
     public enum Category {
         FLIGHT, ACCOMMODATION, FOOD, TRANSPORTATION, TOUR, SHOPPING, OTHERS

--- a/src/main/java/com/snapsplit/backend/domain/receipt/entity/Receipt.java
+++ b/src/main/java/com/snapsplit/backend/domain/receipt/entity/Receipt.java
@@ -1,0 +1,34 @@
+package com.snapsplit.backend.domain.receipt.entity;
+
+import com.snapsplit.backend.domain.expense.entity.Expense;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "receipt")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Receipt {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "receipt_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "expense_id", nullable = false, unique = true)
+    private Expense expense;
+
+    @Column(name = "receipt_url", length = 255, nullable = false)
+    private String receiptUrl;
+
+    /**
+     * 영수증 파싱 결과(JSON 그대로 저장)
+     * MySQL에서는 JSON 타입으로, Hibernate는 String으로 매핑
+     */
+    @Column(name = "extracted_data", columnDefinition = "json")
+    private String extractedData;
+
+}

--- a/src/main/java/com/snapsplit/backend/domain/receipt/entity/Receipt.java
+++ b/src/main/java/com/snapsplit/backend/domain/receipt/entity/Receipt.java
@@ -21,7 +21,7 @@ public class Receipt {
     @JoinColumn(name = "expense_id", nullable = false, unique = true)
     private Expense expense;
 
-    @Column(name = "receipt_url", length = 255, nullable = false)
+    @Column(name = "receipt_url", length = 2048, nullable = false)
     private String receiptUrl;
 
     /**

--- a/src/main/java/com/snapsplit/backend/domain/receipt/repository/ReceiptRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/receipt/repository/ReceiptRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
-    Optional<Receipt> findByExpenseId(Long expenseId);
+    Optional<Receipt> findByExpense_Id(Long expenseId);
 }

--- a/src/main/java/com/snapsplit/backend/domain/receipt/repository/ReceiptRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/receipt/repository/ReceiptRepository.java
@@ -1,0 +1,10 @@
+package com.snapsplit.backend.domain.receipt.repository;
+
+import com.snapsplit.backend.domain.receipt.entity.Receipt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
+    Optional<Receipt> findByExpenseId(Long expenseId);
+}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/AddExpenseRequest.java
@@ -12,7 +12,12 @@ public record AddExpenseRequest(
         @NotNull @Size(min=1)
         List<PayerDto> payers,
         @NotNull @Size(min=1)
-        List<SplitterDto> splitters
+        List<SplitterDto> splitters,
+
+        String receiptUrl, // 영수증 사진 url
+        @Valid
+        List<ReceiptItemDto> items
+
 ) {
 
     public record ExpenseDto(
@@ -44,5 +49,13 @@ public record AddExpenseRequest(
             Long memberId,
             @NotNull @DecimalMin(value = "0.0", inclusive = false)
             BigDecimal splitAmount
+    ) {}
+
+    // 영수증 파싱된 아이템들
+    public record ReceiptItemDto(
+            @NotBlank
+            String name,
+            @NotNull @DecimalMin(value = "0.0", inclusive = false)
+            BigDecimal amount
     ) {}
 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/dto/ExpenseDetailResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/dto/ExpenseDetailResponse.java
@@ -19,11 +19,20 @@ public record ExpenseDetailResponse(
         String expenseMemo,
         String category,
         List<MemberAmountDto> payers,
-        List<MemberAmountDto> splitters
+        List<MemberAmountDto> splitters,
+        // 영수증으로 지출 추가한 경우
+        String receiptUrl,
+        List<ReceiptItemDto> receiptItems
 ) {
     @Builder
     public record MemberAmountDto(
             Long memberId,
+            String name,
+            BigDecimal amount
+    ) {}
+
+    @Builder
+    public record ReceiptItemDto(
             String name,
             BigDecimal amount
     ) {}

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -114,11 +114,13 @@ public class AddExpenseService {
         if (request.receiptUrl() != null) {
             String extractedData = null;
             if (request.items() != null && !request.items().isEmpty()) {
-                // 아이템들을 JSON으로 직렬화해서 저장
-                extractedData = request.items().stream()
-                        .map(i -> String.format("{\"name\":\"%s\",\"amount\":%s}",
-                                i.name().replace("\"", ""), i.amount()))
-                        .collect(Collectors.joining(",", "[", "]"));
+                // ObjectMapper를 사용한 안전한 JSON 직렬화
+                ObjectMapper mapper = new ObjectMapper();
+                try {
+                    extractedData = mapper.writeValueAsString(request.items());
+                } catch (Exception e) {
+                    throw new RuntimeException("영수증 아이템 직렬화 실패", e);
+                }
             }
 
             Receipt receipt = Receipt.builder()
@@ -240,21 +242,18 @@ public class AddExpenseService {
         Receipt receipt = receiptRepository.findByExpense_Id(expenseId).orElse(null);
         String receiptUrl = null;
         List<ExpenseDetailResponse.ReceiptItemDto> receiptItems = null;
+
         if (receipt != null) {
             receiptUrl = receipt.getReceiptUrl();
 
             if (receipt.getExtractedData() != null) {
                 try {
-                    // JSON 파싱 → DTO 변환
                     ObjectMapper mapper = new ObjectMapper();
-                    List<Map<String, Object>> items =
-                            mapper.readValue(receipt.getExtractedData(), new TypeReference<>() {});
-                    receiptItems = items.stream()
-                            .map(i -> ExpenseDetailResponse.ReceiptItemDto.builder()
-                                    .name((String) i.get("name"))
-                                    .amount(new BigDecimal(i.get("amount").toString()))
-                                    .build())
-                            .toList();
+                    // ReceiptItemDto 바로 역직렬화
+                    receiptItems = mapper.readValue(
+                            receipt.getExtractedData(),
+                            new TypeReference<List<ExpenseDetailResponse.ReceiptItemDto>>() {}
+                    );
                 } catch (Exception e) {
                     // 파싱 실패하면 null 유지
                 }

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -1,7 +1,11 @@
 package com.snapsplit.backend.feature.addExpense.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snapsplit.backend.domain.expense.entity.*;
 import com.snapsplit.backend.domain.expense.repository.*;
+import com.snapsplit.backend.domain.receipt.entity.Receipt;
+import com.snapsplit.backend.domain.receipt.repository.ReceiptRepository;
 import com.snapsplit.backend.domain.shared.entity.PaymentMethod;
 import com.snapsplit.backend.domain.shared.entity.Shared;
 import com.snapsplit.backend.domain.shared.repository.SharedRepository;
@@ -14,6 +18,7 @@ import com.snapsplit.backend.feature.addExpense.dto.AddExpenseRequest;
 import com.snapsplit.backend.feature.addExpense.dto.ExpenseDetailResponse;
 import com.snapsplit.backend.domain.shared.entity.SharedType;
 import com.snapsplit.backend.feature.getCategoryExpense.service.CategoryExpenseService;
+import com.snapsplit.backend.feature.receipt.service.ReceiptService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,7 +42,7 @@ public class AddExpenseService {
     private final TotalSharedRepository totalSharedRepository;
     private final TripRepository tripRepository;
     private final CategoryExpenseService categoryExpenseService;
-
+    private final ReceiptRepository receiptRepository;
 
 
     //지출 추가
@@ -104,6 +109,26 @@ public class AddExpenseService {
                         .paymentMethod(Expense.PaymentMethod.valueOf(info.paymentMethod().toUpperCase()))
                         .build()
         );
+
+        // 영수증으로 지출 추가한 경우
+        if (request.receiptUrl() != null) {
+            String extractedData = null;
+            if (request.items() != null && !request.items().isEmpty()) {
+                // 아이템들을 JSON으로 직렬화해서 저장
+                extractedData = request.items().stream()
+                        .map(i -> String.format("{\"name\":\"%s\",\"amount\":%s}",
+                                i.name().replace("\"", ""), i.amount()))
+                        .collect(Collectors.joining(",", "[", "]"));
+            }
+
+            Receipt receipt = Receipt.builder()
+                    .expense(expense)
+                    .receiptUrl(request.receiptUrl())
+                    .extractedData(extractedData)
+                    .build();
+
+            receiptRepository.save(receipt);
+        }
 
         // 결제자 저장 & 공동 경비 처리
         List<Pay> pays = request.payers().stream()
@@ -211,6 +236,30 @@ public class AddExpenseService {
                             .build();
                 }).toList();
 
+        // 영수증으로 지출 추가한 지출일 경우
+        Receipt receipt = receiptRepository.findByExpenseId(expenseId).orElse(null);
+        String receiptUrl = null;
+        List<ExpenseDetailResponse.ReceiptItemDto> receiptItems = null;
+        if (receipt != null) {
+            receiptUrl = receipt.getReceiptUrl();
+
+            if (receipt.getExtractedData() != null) {
+                try {
+                    // JSON 파싱 → DTO 변환
+                    ObjectMapper mapper = new ObjectMapper();
+                    List<Map<String, Object>> items =
+                            mapper.readValue(receipt.getExtractedData(), new TypeReference<>() {});
+                    receiptItems = items.stream()
+                            .map(i -> ExpenseDetailResponse.ReceiptItemDto.builder()
+                                    .name((String) i.get("name"))
+                                    .amount(new BigDecimal(i.get("amount").toString()))
+                                    .build())
+                            .toList();
+                } catch (Exception e) {
+                    // 파싱 실패하면 null 유지
+                }
+            }
+        }
         return ExpenseDetailResponse.builder()
                 .expenseId(expense.getId())
                 .amount(expense.getExpenseAmount())
@@ -223,6 +272,8 @@ public class AddExpenseService {
                 .category(expense.getCategory().toString())
                 .payers(payers)
                 .splitters(splitters)
+                .receiptUrl(receiptUrl)
+                .receiptItems(receiptItems)
                 .build();
     }
 

--- a/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
+++ b/src/main/java/com/snapsplit/backend/feature/addExpense/service/AddExpenseService.java
@@ -237,7 +237,7 @@ public class AddExpenseService {
                 }).toList();
 
         // 영수증으로 지출 추가한 지출일 경우
-        Receipt receipt = receiptRepository.findByExpenseId(expenseId).orElse(null);
+        Receipt receipt = receiptRepository.findByExpense_Id(expenseId).orElse(null);
         String receiptUrl = null;
         List<ExpenseDetailResponse.ReceiptItemDto> receiptItems = null;
         if (receipt != null) {

--- a/src/main/java/com/snapsplit/backend/feature/receipt/controller/ReceiptController.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/controller/ReceiptController.java
@@ -1,0 +1,35 @@
+package com.snapsplit.backend.feature.receipt.controller;
+
+import com.snapsplit.backend.feature.receipt.dto.ReceiptRequest;
+import com.snapsplit.backend.feature.receipt.dto.ReceiptResponse;
+import com.snapsplit.backend.feature.receipt.service.ReceiptService;
+import com.snapsplit.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartException;
+
+@Tag(name = "영수증 OCR", description = "Document AI Expense Parser를 이용한 영수증 파싱")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/receipts")
+public class ReceiptController {
+
+    private final ReceiptService receiptService;
+
+    @Operation(summary = "영수증 파싱", description = "영수증 이미지를 업로드하면 영수증을 파싱하여 필요한 데이터만을 반환합니다.")
+    @PostMapping(value = "/parse", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ReceiptResponse> parse(@ModelAttribute @Valid ReceiptRequest request) {
+        ReceiptResponse data = receiptService.parse(request);
+        return ApiResponse.success("영수증 파싱 성공", data);
+    }
+
+    // 업로드 관련 예외 간단 처리
+    @ExceptionHandler(MultipartException.class)
+    public ApiResponse<Object> handleMultipart(MultipartException e) {
+        return ApiResponse.fail(400, "업로드 오류: " + e.getMessage());
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/receipt/controller/ReceiptDebugController.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/controller/ReceiptDebugController.java
@@ -1,4 +1,3 @@
-// ReceiptController.java
 package com.snapsplit.backend.feature.receipt.controller;
 
 import com.snapsplit.backend.feature.receipt.dto.ReceiptDebugResponse;

--- a/src/main/java/com/snapsplit/backend/feature/receipt/controller/ReceiptDebugController.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/controller/ReceiptDebugController.java
@@ -1,0 +1,34 @@
+// ReceiptController.java
+package com.snapsplit.backend.feature.receipt.controller;
+
+import com.snapsplit.backend.feature.receipt.dto.ReceiptDebugResponse;
+import com.snapsplit.backend.feature.receipt.dto.ReceiptRequest;
+import com.snapsplit.backend.feature.receipt.service.ReceiptDebug;
+import com.snapsplit.backend.feature.receipt.service.ReceiptService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "영수증 OCR", description = "Document AI Expense Parser를 이용한 영수증 파싱")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/receipts")
+public class ReceiptDebugController {
+
+    private final ReceiptDebug receiptService;
+
+
+    /** OCR 원본 디버그용: Document 전체 JSON + rawText + 엔티티 요약 */
+    @Operation(summary = "영수증 원본 디버그용", description = "Document 전체 JSON + rawText + 엔티티 요약")
+    @PostMapping("/debug")
+    public ResponseEntity<ReceiptDebugResponse> debug(
+            @ModelAttribute ReceiptRequest request,
+            @RequestParam(name = "pretty", defaultValue = "false") boolean pretty,
+            @RequestParam(name = "entitiesLimit", defaultValue = "200") int entitiesLimit
+    ) {
+        return ResponseEntity.ok(receiptService.debug(request, pretty, entitiesLimit));
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/receipt/dto/ReceiptDebugResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/dto/ReceiptDebugResponse.java
@@ -1,0 +1,28 @@
+// ReceiptDebugResponse.java
+package com.snapsplit.backend.feature.receipt.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter @Builder @AllArgsConstructor @NoArgsConstructor
+public class ReceiptDebugResponse {
+    private String rawText;           // 원문 텍스트 (길이 제한)
+    private boolean rawTextTruncated; // 잘렸는지 표시
+    private String documentJson;      // Document 전체 JSON (길이 제한)
+    private boolean documentJsonTruncated;
+    private int pageCount;            // 페이지 수
+    private int entityCount;          // 엔티티 총개수(실제)
+    private List<EntityRow> entities; // 엔티티 요약 표 (상위 N개)
+
+    @Getter @Builder @AllArgsConstructor @NoArgsConstructor
+    public static class EntityRow {
+        private String type;              // e.g. total, line_item, amount
+        private String mentionText;       // 화면 보인 텍스트
+        private String normalizedText;    // normalized_value.text
+        private String moneyCurrency;     // normalized_value.money_value.currency_code
+        private String moneyAmount;       // normalized_value.money_value (units+nanos)
+        private Double confidence;        // 엔티티 confidence
+        private int propertyCount;        // 하위 속성 개수
+        private String pageRefs;          // 페이지 앵커 간단 요약
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/receipt/dto/ReceiptRequest.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/dto/ReceiptRequest.java
@@ -1,0 +1,13 @@
+package com.snapsplit.backend.feature.receipt.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter @Setter
+public class ReceiptRequest {
+
+    @NotNull(message = "영수증 이미지 파일은 필수입니다.")
+    private MultipartFile file;
+}

--- a/src/main/java/com/snapsplit/backend/feature/receipt/dto/ReceiptResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/dto/ReceiptResponse.java
@@ -12,6 +12,7 @@ public class ReceiptResponse {
 
     private String currency; // 통화
     private BigDecimal totalAmount; // 총액
+    private String receiptUrl; // 영수증 url
     /** 아이템 (이름/금액) */
     private List<UiItem> items;
 

--- a/src/main/java/com/snapsplit/backend/feature/receipt/dto/ReceiptResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/dto/ReceiptResponse.java
@@ -1,0 +1,23 @@
+package com.snapsplit.backend.feature.receipt.dto;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReceiptResponse {
+
+    private String currency; // 통화
+    private BigDecimal totalAmount; // 총액
+    /** 아이템 (이름/금액) */
+    private List<UiItem> items;
+
+    @Getter @Builder @AllArgsConstructor @NoArgsConstructor
+    public static class UiItem {
+        private String name; // 상품명
+        private BigDecimal amount; // 금액
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptDebug.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptDebug.java
@@ -1,0 +1,130 @@
+package com.snapsplit.backend.feature.receipt.service;
+
+import com.google.protobuf.util.JsonFormat;
+import com.google.cloud.documentai.v1.*;
+import com.google.protobuf.ByteString;
+import com.snapsplit.backend.feature.receipt.dto.ReceiptDebugResponse;
+import com.snapsplit.backend.feature.receipt.dto.ReceiptRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReceiptDebug {
+
+    private final DocumentProcessorServiceClient client;
+
+    @Value("${gcp.docai.project-id}")
+    private String projectId;
+
+    @Value("${gcp.docai.location}")
+    private String location;
+
+    @Value("${gcp.docai.processor-id}")
+    private String processorId;
+
+    public ReceiptDebugResponse debug(ReceiptRequest request, boolean pretty, int entitiesLimit) {
+        try {
+            MultipartFile file = request.getFile();
+            String mimeType = (file.getContentType() != null) ? file.getContentType() : "image/jpeg";
+
+            String processor = ProcessorName.of(projectId, location, processorId).toString();
+            RawDocument rawDocument = RawDocument.newBuilder()
+                    .setContent(ByteString.copyFrom(file.getBytes()))
+                    .setMimeType(mimeType)
+                    .build();
+
+            ProcessRequest pr = ProcessRequest.newBuilder()
+                    .setName(processor)
+                    .setRawDocument(rawDocument)
+                    .build();
+
+            ProcessResponse resp = client.processDocument(pr);
+            Document doc = resp.getDocument();
+
+            // 1) raw text (길이 제한)
+            final int RAW_LIMIT = 200_000; // 200KB 정도
+            String rawText = doc.getText();
+            boolean rawTrunc = rawText != null && rawText.length() > RAW_LIMIT;
+            rawText = clamp(rawText, RAW_LIMIT);
+
+            // 2) 전체 Document JSON (길이 제한)
+            String json;
+            JsonFormat.Printer printer = JsonFormat.printer().includingDefaultValueFields();
+            // JsonFormat 기본은 pretty 없음 → 필요하면 그대로(긴 한 줄). pretty 원하면 가볍게 줄바꿈만 처리
+            json = printer.print(doc);
+            if (pretty) json = json.replaceAll(",", ",\n"); // 매우 러프한 보기용 개행 (원하면 Jackson으로 포매팅해도 됨)
+
+            final int JSON_LIMIT = 1_000_000; // 1MB
+            boolean jsonTrunc = json.length() > JSON_LIMIT;
+            json = clamp(json, JSON_LIMIT);
+
+            // 3) 엔티티 요약 표 (상위 N개)
+            List<ReceiptDebugResponse.EntityRow> rows = new ArrayList<>();
+            int totalEntities = doc.getEntitiesCount();
+            int cap = Math.max(1, Math.min(entitiesLimit, totalEntities));
+            for (int i = 0; i < cap; i++) {
+                Document.Entity e = doc.getEntities(i);
+                String type = nte(e.getType());
+                String mention = nte(e.getMentionText());
+                String normText = e.hasNormalizedValue() ? nte(e.getNormalizedValue().getText()) : null;
+                String moneyCode = null;
+                String moneyAmount = null;
+                if (e.hasNormalizedValue() && e.getNormalizedValue().hasMoneyValue()) {
+                    com.google.type.Money m = e.getNormalizedValue().getMoneyValue();
+                    moneyCode = nte(m.getCurrencyCode());
+                    // units + nanos(9자리) 조합
+                    moneyAmount = m.getUnits() + (m.getNanos() == 0 ? "" : ("." + String.format("%09d", m.getNanos())));
+                    // 소수점 우측 불필요한 0 제거
+                    moneyAmount = moneyAmount.replaceAll("\\.?0+$", "");
+                }
+                String pageRefs = "";
+                if (e.hasPageAnchor()) {
+                    var pa = e.getPageAnchor();
+                    if (pa.getPageRefsCount() > 0) {
+                        StringBuilder sb = new StringBuilder();
+                        for (int k = 0; k < Math.min(3, pa.getPageRefsCount()); k++) {
+                            var ref = pa.getPageRefs(k);
+                            sb.append("#").append(ref.getPage()).append(" ");
+                        }
+                        pageRefs = sb.toString().trim();
+                    }
+                }
+                rows.add(ReceiptDebugResponse.EntityRow.builder()
+                        .type(type)
+                        .mentionText(mention)
+                        .normalizedText(normText)
+                        .moneyCurrency(moneyCode)
+                        .moneyAmount(moneyAmount)
+                        .confidence((double) e.getConfidence())
+                        .propertyCount(e.getPropertiesCount())
+                        .pageRefs(pageRefs)
+                        .build());
+            }
+
+            return ReceiptDebugResponse.builder()
+                    .rawText(rawText)
+                    .rawTextTruncated(rawTrunc)
+                    .documentJson(json)
+                    .documentJsonTruncated(jsonTrunc)
+                    .pageCount(doc.getPagesCount())
+                    .entityCount(totalEntities)
+                    .entities(rows)
+                    .build();
+
+        } catch (Exception e) {
+            throw new RuntimeException("OCR 디버그 조회 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private static String clamp(String s, int limit) {
+        if (s == null) return null;
+        return s.length() <= limit ? s : s.substring(0, limit);
+    }
+    private static String nte(String s) { return (s == null || s.isBlank()) ? null : s; }
+}

--- a/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptGarbageCollector.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptGarbageCollector.java
@@ -4,11 +4,15 @@ import com.snapsplit.backend.domain.receipt.entity.Receipt;
 import com.snapsplit.backend.domain.receipt.repository.ReceiptRepository;
 import com.snapsplit.backend.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReceiptGarbageCollector {
@@ -16,21 +20,34 @@ public class ReceiptGarbageCollector {
     private final ReceiptRepository receiptRepository;
     private final S3Uploader s3Uploader;
 
-    // 매일 새벽 3시에 실행
     @Scheduled(cron = "0 0 3 * * *")
     public void cleanUnusedReceipts() {
-        // 1) DB에 남아있는 영수증 URL 전부 가져오기
-        List<String> usedUrls = receiptRepository.findAll()
-                .stream()
-                .map(Receipt::getReceiptUrl)
-                .toList();
+        // 1) DB에 남아있는 영수증 URL을 Set으로 저장 (검색 성능 향상)
+        Set<String> usedUrls = new HashSet<>(
+                receiptRepository.findAll()
+                        .stream()
+                        .map(Receipt::getReceiptUrl)
+                        .toList()
+        );
 
         // 2) S3에 저장된 모든 영수증 파일 목록 가져오기
         List<String> allObjects = s3Uploader.listObjects("receipt-images");
 
-        // 3) DB에 없는 파일만 삭제
-        allObjects.stream()
+        // 3) DB에 없는 파일만 수집
+        List<String> urlsToDelete = allObjects.stream()
                 .filter(url -> !usedUrls.contains(url))
-                .forEach(s3Uploader::delete);
+                .toList();
+
+        // 4) 배치 삭제
+        for (String url : urlsToDelete) {
+            try {
+                s3Uploader.delete(url);
+                log.info("Deleted unused receipt: {}", url);
+            } catch (Exception e) {
+                // 개별 삭제 실패 로깅하고 계속 진행
+                log.error("Failed to delete unused receipt: {}", url, e);
+            }
+        }
     }
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptGarbageCollector.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptGarbageCollector.java
@@ -1,0 +1,36 @@
+package com.snapsplit.backend.feature.receipt.service;
+
+import com.snapsplit.backend.domain.receipt.entity.Receipt;
+import com.snapsplit.backend.domain.receipt.repository.ReceiptRepository;
+import com.snapsplit.backend.global.s3.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReceiptGarbageCollector {
+
+    private final ReceiptRepository receiptRepository;
+    private final S3Uploader s3Uploader;
+
+    // 매일 새벽 3시에 실행
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanUnusedReceipts() {
+        // 1) DB에 남아있는 영수증 URL 전부 가져오기
+        List<String> usedUrls = receiptRepository.findAll()
+                .stream()
+                .map(Receipt::getReceiptUrl)
+                .toList();
+
+        // 2) S3에 저장된 모든 영수증 파일 목록 가져오기
+        List<String> allObjects = s3Uploader.listObjects("receipt-images");
+
+        // 3) DB에 없는 파일만 삭제
+        allObjects.stream()
+                .filter(url -> !usedUrls.contains(url))
+                .forEach(s3Uploader::delete);
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
@@ -187,7 +187,7 @@ public class ReceiptService {
     }
 
     private static final Pattern ISO_CODE = Pattern.compile(
-            "\\b(USD|AUD|CAD|NZD|SGD|HKD|TWD|JPY|EUR|GBP|CHF|SEK|NOK|DKK|PLN|CZK|HUF|TRY|ILS|INR|AED|SAR|THB|IDR|MYR|VND|ZAR|BRL|MXN|PHP|RUB|CNY)\\b",
+            "\\b(USD|AUD|CAD|NZD|SGD|HKD|TWD|JPY|EUR|GBP|CHF|SEK|NOK|DKK|PLN|CZK|HUF|TRY|ILS|INR|AED|SAR|THB|IDR|MYR|VND|ZAR|BRL|MXN|PHP|RUB|CNY|KRW)\\b",
             Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
@@ -1,0 +1,431 @@
+package com.snapsplit.backend.feature.receipt.service;
+
+import com.google.cloud.documentai.v1.Document;
+import com.google.cloud.documentai.v1.DocumentProcessorServiceClient;
+import com.google.cloud.documentai.v1.ProcessorName;
+import com.google.cloud.documentai.v1.ProcessRequest;
+import com.google.cloud.documentai.v1.ProcessResponse;
+import com.google.cloud.documentai.v1.RawDocument;
+import com.snapsplit.backend.feature.receipt.dto.ReceiptRequest;
+import com.snapsplit.backend.feature.receipt.dto.ReceiptResponse;
+import com.google.protobuf.ByteString;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class ReceiptService {
+
+    private final DocumentProcessorServiceClient client;
+
+    @Value("${gcp.docai.project-id}")
+    private String projectId;
+
+    @Value("${gcp.docai.location}")
+    private String location;
+
+    @Value("${gcp.docai.processor-id}")
+    private String processorId;
+
+    // ===================== Public API =====================
+
+    /**
+     * 영수증 이미지를 DocAI Expense Parser로 처리하고,
+     * - 통화(currency): 엔티티/원문 힌트에서 추출
+     * - 아이템(items): line_item 엔티티만 보고 단순 규칙으로 추출
+     * - 총액(totalAmount): "항상" 아이템 금액 합계로 산출
+     */
+    public ReceiptResponse parse(ReceiptRequest request) {
+        try {
+            MultipartFile file = request.getFile();
+            String mimeType = (file.getContentType() != null) ? file.getContentType() : "image/jpeg";
+
+            String processor = ProcessorName.of(projectId, location, processorId).toString();
+            RawDocument rawDocument = RawDocument.newBuilder()
+                    .setContent(ByteString.copyFrom(file.getBytes()))
+                    .setMimeType(mimeType)
+                    .build();
+
+            ProcessRequest pr = ProcessRequest.newBuilder()
+                    .setName(processor)
+                    .setRawDocument(rawDocument)
+                    .build();
+
+            ProcessResponse resp = client.processDocument(pr);
+            Document doc = resp.getDocument();
+
+            // rawText: 통화 추정에만 사용
+            String rawText = safeClamp(doc.getText(), 20_000);
+
+            // ---- Currency (코드 > 심볼 > hint) ----
+            String currencyCodeFromEntities = pickCurrencyCode(doc);
+            String currencyCodeFromRaw      = detectCurrencyCodeFromRaw(rawText);
+            String currencySymbol           = firstNonEmpty(
+                    getEntityTextAny(doc, "currency_symbol", "currency"),
+                    detectCurrencySymbolFromRaw(rawText),
+                    symbolFromCurrencyCode(currencyCodeFromEntities),
+                    symbolFromCurrencyCode(currencyCodeFromRaw)
+            );
+            String currencyFinal = firstNonEmpty(
+                    currencyCodeFromEntities,
+                    currencyCodeFromRaw,
+                    currencySymbol
+            );
+
+            // ---- Items: line_item만 보고 단순 규칙으로 뽑기 (기존)
+            List<ReceiptResponse.UiItem> items = extractUiItems(doc);
+
+            // ---- TAX 라인 추가 (중복 방지)
+            BigDecimal tax = computeTaxFromEntities(doc); // 아래 헬퍼 추가
+            if (tax != null && tax.compareTo(BigDecimal.ZERO) > 0 && !hasTaxItem(items)) {
+                items.add(ReceiptResponse.UiItem.builder()
+                        .name("TAX")
+                        .amount(tax)
+                        .build());
+            }
+
+            // ---- Total: 아이템 합계 (세금이 items에 포함되었으니 자동 포함)
+            BigDecimal total = items.stream()
+                    .map(ReceiptResponse.UiItem::getAmount)
+                    .filter(Objects::nonNull)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+            return ReceiptResponse.builder()
+                    .currency(currencyFinal)
+                    .totalAmount(total)
+                    .items(items)
+                    .build();
+
+        } catch (Exception e) {
+            throw new RuntimeException("영수증 파싱 실패: " + e.getMessage(), e);
+        }
+    }
+
+    // ===================== Entities Helpers =====================
+
+    private String getEntityText(Document doc, String type) {
+        for (Document.Entity e : doc.getEntitiesList()) {
+            if (type.equalsIgnoreCase(e.getType())) {
+                String mt = nullToEmpty(e.getMentionText()).trim();
+                if (!mt.isEmpty()) return mt;
+                if (e.hasNormalizedValue()) {
+                    String nv = nullToEmpty(e.getNormalizedValue().getText()).trim();
+                    if (!nv.isEmpty()) return nv;
+                }
+            }
+        }
+        return null;
+    }
+
+    private String getEntityTextAny(Document doc, String... types) {
+        for (String t : types) {
+            String v = getEntityText(doc, t);
+            if (v != null && !v.isBlank()) return v;
+        }
+        return null;
+    }
+
+    // ===================== Currency (코드/심볼) =====================
+
+    private String pickCurrencyCode(Document doc) {
+        // currency 엔티티 우선
+        for (Document.Entity e : doc.getEntitiesList()) {
+            if ("currency".equalsIgnoreCase(e.getType()) && e.hasNormalizedValue()) {
+                String t = nullToEmpty(e.getNormalizedValue().getText()).trim();
+                if (!t.isBlank()) return t.toUpperCase();
+                if (e.getNormalizedValue().hasMoneyValue()) {
+                    String code = e.getNormalizedValue().getMoneyValue().getCurrencyCode();
+                    if (code != null && !code.isBlank()) return code.toUpperCase();
+                }
+            }
+        }
+        // 금액성 엔티티/라인 아이템 속성
+        Set<String> moneyFields = new HashSet<>(Arrays.asList(
+                "total","grand_total","amount_due","subtotal","tax","tip","amount","line_total","unit_price"
+        ));
+        for (Document.Entity e : doc.getEntitiesList()) {
+            String type = nullToEmpty(e.getType()).toLowerCase();
+            if (moneyFields.contains(type)) {
+                if (e.hasNormalizedValue() && e.getNormalizedValue().hasMoneyValue()) {
+                    String code = e.getNormalizedValue().getMoneyValue().getCurrencyCode();
+                    if (code != null && !code.isBlank()) return code.toUpperCase();
+                }
+            }
+            if ("line_item".equalsIgnoreCase(e.getType())) {
+                for (Document.Entity p : e.getPropertiesList()) {
+                    String pt = nullToEmpty(p.getType()).toLowerCase();
+                    if (pt.equals("amount") || pt.equals("line_total") || pt.equals("unit_price")) {
+                        if (p.hasNormalizedValue() && p.getNormalizedValue().hasMoneyValue()) {
+                            String code = p.getNormalizedValue().getMoneyValue().getCurrencyCode();
+                            if (code != null && !code.isBlank()) return code.toUpperCase();
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static final Pattern ISO_CODE = Pattern.compile(
+            "\\b(USD|AUD|CAD|NZD|SGD|HKD|TWD|JPY|EUR|GBP|CHF|SEK|NOK|DKK|PLN|CZK|HUF|TRY|ILS|INR|AED|SAR|THB|IDR|MYR|VND|ZAR|BRL|MXN|PHP|RUB|CNY)\\b",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    private String detectCurrencyCodeFromRaw(String raw) {
+        if (raw == null) return null;
+
+        Matcher m = ISO_CODE.matcher(raw);
+        if (m.find()) return m.group(1).toUpperCase();
+
+        Map<String, String> prefixed = new LinkedHashMap<>();
+        prefixed.put("NT$", "TWD"); prefixed.put("HK$", "HKD"); prefixed.put("A$", "AUD"); prefixed.put("AU$", "AUD");
+        prefixed.put("S$", "SGD");  prefixed.put("CA$", "CAD"); prefixed.put("C$", "CAD");  prefixed.put("NZ$", "NZD");
+        prefixed.put("R$", "BRL");  prefixed.put("MX$", "MXN"); prefixed.put("MEX$", "MXN");
+        for (var e : prefixed.entrySet()) if (raw.contains(e.getKey())) return e.getValue();
+
+        if (raw.contains("₩")) return "KRW";
+        if (raw.contains("₹")) return "INR";
+        if (raw.contains("฿")) return "THB";
+        if (raw.contains("₱")) return "PHP";
+        if (raw.contains("₽")) return "RUB";
+        if (raw.contains("₺")) return "TRY";
+        if (raw.contains("₪")) return "ILS";
+        if (raw.contains("₫")) return "VND";
+        if (raw.contains("CHF") || raw.contains(" Fr") || raw.contains("Fr.")) return "CHF";
+
+        if (raw.contains("¥")) {
+            if (raw.matches(".*(円|税込|東京都|大阪|日本|〒|\\bJP\\b|\\bJPN\\b).*")) return "JPY";
+            if (raw.matches(".*(人民币|人民幣|元|中國|中国|\\bCN\\b|\\bCHN\\b).*")) return "CNY";
+        }
+
+        if (raw.contains("$")) return "USD";
+        if (raw.contains("£")) return "GBP";
+        if (raw.contains("€")) return "EUR";
+        return null;
+    }
+
+    private String detectCurrencySymbolFromRaw(String raw) {
+        if (raw == null) return null;
+        if (raw.contains("₩")) return "₩";
+        if (raw.contains("₹")) return "₹";
+        if (raw.contains("฿")) return "฿";
+        if (raw.contains("₱")) return "₱";
+        if (raw.contains("₽")) return "₽";
+        if (raw.contains("₺")) return "₺";
+        if (raw.contains("₪")) return "₪";
+        if (raw.contains("₫")) return "₫";
+        String[] dollarPrefixes = {"NT$", "HK$", "A$", "AU$", "S$", "CA$", "C$", "NZ$", "R$", "MX$", "MEX$"};
+        for (String p : dollarPrefixes) if (raw.contains(p)) return "$";
+        if (raw.contains("€")) return "€";
+        if (raw.contains("£")) return "£";
+        if (raw.contains("¥")) return "¥";
+        if (raw.contains("$")) return "$";
+        return null;
+    }
+
+    private String symbolFromCurrencyCode(String code) {
+        if (code == null) return null;
+        return switch (code) {
+            case "USD","AUD","CAD","NZD","SGD","HKD","TWD","MXN","BRL" -> "$";
+            case "EUR" -> "€";
+            case "GBP" -> "£";
+            case "JPY","CNY" -> "¥";
+            case "KRW" -> "₩";
+            case "INR" -> "₹";
+            case "THB" -> "฿";
+            case "PHP" -> "₱";
+            case "RUB" -> "₽";
+            case "TRY" -> "₺";
+            case "ILS" -> "₪";
+            case "VND" -> "₫";
+            case "CHF" -> "Fr";
+            default -> null;
+        };
+    }
+
+    // ===================== UI Items =====================
+
+    // 숫자 패턴(그룹화 쉼표/소수점 허용) — 라인 내 "마지막 숫자"를 금액으로 사용
+    private static final Pattern NUM = Pattern.compile("\\d{1,3}(?:,\\d{3})*(?:\\.\\d{1,2})?");
+
+    /**
+     * line_item 엔티티만 보고 단순 규칙으로 아이템을 만든다.
+     * (문자+숫자) → 마지막 숫자를 amount, 앞부분을 name
+     */
+    private List<ReceiptResponse.UiItem> extractUiItems(Document doc) {
+        List<ReceiptResponse.UiItem> out = new ArrayList<>();
+
+        for (Document.Entity e : doc.getEntitiesList()) {
+            if (!"line_item".equalsIgnoreCase(e.getType())) continue;
+
+            String mt = e.getMentionText();
+            if (mt == null || mt.isBlank()) continue;
+
+            for (String raw : mt.split("\\R+")) {
+                String line = raw.strip();
+                if (line.isEmpty()) continue;
+
+                boolean hasLetter = line.matches(".*\\p{L}.*");
+                boolean hasDigit  = line.matches(".*\\d.*");
+
+                // 문자 + 숫자 케이스만 처리
+                if (hasLetter && hasDigit) {
+                    Matcher m = NUM.matcher(line);
+                    int lastStart = -1; String lastNum = null;
+                    while (m.find()) { lastStart = m.start(); lastNum = m.group(); }
+                    if (lastNum != null) {
+                        String name = line.substring(0, lastStart).trim();
+                        out.add(ReceiptResponse.UiItem.builder()
+                                .name(cleanDescription(name))
+                                .amount(toBig(lastNum))
+                                .build());
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+
+    // 엔티티의 normalized moneyValue 또는 normalized text에서 금액 추출
+    private BigDecimal moneyFromEntity(Document.Entity e) {
+        try {
+            if (e.hasNormalizedValue()) {
+                var nv = e.getNormalizedValue();
+                if (nv.hasMoneyValue()) {
+                    var mv = nv.getMoneyValue(); // google.type.Money
+                    BigDecimal units = BigDecimal.valueOf(mv.getUnits());
+                    BigDecimal nanos = BigDecimal.valueOf(mv.getNanos()).movePointLeft(9);
+                    return units.add(nanos);
+                }
+                BigDecimal v = toBig(nv.getText());
+                if (v != null) return v;
+            }
+        } catch (Exception ignore) {}
+        return null;
+    }
+
+    // ===================== Utils =====================
+
+    private BigDecimal toBig(String s) {
+        try {
+            if (s == null || s.isBlank()) return null;
+            String t = s.trim();
+            boolean neg = false;
+            if (t.startsWith("(") && t.endsWith(")")) { neg = true; t = t.substring(1, t.length() - 1); }
+            t = t.replaceAll("[^0-9.\\-]", "");
+            if (t.isBlank()) return null;
+            BigDecimal v = new BigDecimal(t);
+            return neg ? v.negate() : v;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String cleanDescription(String s) {
+        if (s == null) return null;
+        s = s.replace("'", "").replace("`", "");
+        s = s.replaceAll("^\\*+\\s*", "");
+        s = s.replaceAll("\\bi\\s*MPERFECT\\b", "IMPERFECT");
+        s = s.replace("STR AWB", "STRAWB");
+        return s.replaceAll("\\s+", " ").trim();
+    }
+
+    private String nullToEmpty(String s) { return (s == null) ? "" : s; }
+
+    private String firstNonEmpty(String... vals) {
+        for (String v : vals) {
+            if (v != null && !v.isBlank()) return v;
+        }
+        return null;
+    }
+
+    private String safeClamp(String s, int limit) {
+        if (s == null) return null;
+        return (s.length() <= limit) ? s : s.substring(0, limit);
+    }
+
+    // 엔티티들에서 세금 금액 계산:
+// 우선순위: total_tax_amount → (total_amount - net_amount) → 라인아이템 세금합
+    private BigDecimal computeTaxFromEntities(Document doc) {
+        BigDecimal entTax   = pickMoney(doc, "total_tax_amount");
+        if (entTax != null) return entTax;
+
+        BigDecimal entTotal = pickMoney(doc, "total_amount", "grand_total", "amount_due");
+        BigDecimal entNet   = pickMoney(doc, "net_amount", "subtotal", "subtotal_amount");
+        if (entTotal != null && entNet != null) {
+            return entTotal.subtract(entNet);
+        }
+
+        return sumLineItemTaxes(doc); // 없으면 null
+    }
+
+    // 엔티티들에서 금액 하나 추출(우선순위): moneyValue → normalized.text → mentionText
+    private BigDecimal pickMoney(Document doc, String... types) {
+        for (String t : types) {
+            for (Document.Entity e : doc.getEntitiesList()) {
+                if (!t.equalsIgnoreCase(e.getType())) continue;
+
+                if (e.hasNormalizedValue() && e.getNormalizedValue().hasMoneyValue()) {
+                    var mv = e.getNormalizedValue().getMoneyValue();
+                    BigDecimal units = BigDecimal.valueOf(mv.getUnits());
+                    BigDecimal nanos = BigDecimal.valueOf(mv.getNanos()).movePointLeft(9);
+                    return units.add(nanos);
+                }
+                if (e.hasNormalizedValue()) {
+                    BigDecimal v = toBig(e.getNormalizedValue().getText());
+                    if (v != null) return v;
+                }
+                BigDecimal v = toBig(e.getMentionText());
+                if (v != null) return v;
+            }
+        }
+        return null;
+    }
+
+    // 라인아이템 하위 속성 세금 합계(있을 때만)
+// 커버 타입: tax, tax_amount, vat, gst, hst, pst
+    private BigDecimal sumLineItemTaxes(Document doc) {
+        BigDecimal sum = BigDecimal.ZERO;
+        boolean hit = false;
+        for (Document.Entity li : doc.getEntitiesList()) {
+            if (!"line_item".equalsIgnoreCase(li.getType())) continue;
+            for (Document.Entity p : li.getPropertiesList()) {
+                String pt = (p.getType() == null) ? "" : p.getType().toLowerCase();
+                if (!(pt.equals("tax") || pt.equals("tax_amount") || pt.equals("vat") ||
+                        pt.equals("gst") || pt.equals("hst") || pt.equals("pst"))) continue;
+
+                BigDecimal v = null;
+                if (p.hasNormalizedValue() && p.getNormalizedValue().hasMoneyValue()) {
+                    var mv = p.getNormalizedValue().getMoneyValue();
+                    v = BigDecimal.valueOf(mv.getUnits())
+                            .add(BigDecimal.valueOf(mv.getNanos()).movePointLeft(9));
+                } else if (p.hasNormalizedValue()) {
+                    v = toBig(p.getNormalizedValue().getText());
+                }
+                if (v == null) v = toBig(p.getMentionText());
+
+                if (v != null) { sum = sum.add(v); hit = true; }
+            }
+        }
+        return hit ? sum : null;
+    }
+
+    private boolean hasTaxItem(List<ReceiptResponse.UiItem> items) {
+        if (items == null) return false;
+        for (var it : items) {
+            String n = (it.getName() == null) ? "" : it.getName().toLowerCase();
+            if (n.matches(".*\\b(tax|sales\\s*tax|vat|gst|hst|pst|iva)\\b.*")) return true;
+        }
+        return false;
+    }
+
+
+}

--- a/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
@@ -13,6 +13,7 @@ import com.snapsplit.backend.global.exception.ReceiptProcessingException;
 import com.snapsplit.backend.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -70,8 +71,15 @@ public class ReceiptService {
                     .setRawDocument(rawDocument)
                     .build();
 
-            ProcessResponse resp = client.processDocument(pr);
-            Document doc = resp.getDocument();
+            Document doc;
+            try {
+                ProcessResponse resp = client.processDocument(pr);
+                doc = resp.getDocument();
+            } catch (com.google.api.gax.rpc.ApiException ex) {
+                // 네트워크/서비스 오류 → 502 매핑 (rate limit/exhaustion은 필요시 503 고려)
+                throw new ReceiptProcessingException("DocAI 호출 실패");
+            }
+
 
             // rawText: 통화 추정에만 사용
             String rawText = safeClamp(doc.getText(), 20_000);

--- a/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
@@ -9,12 +9,14 @@ import com.google.cloud.documentai.v1.RawDocument;
 import com.snapsplit.backend.feature.receipt.dto.ReceiptRequest;
 import com.snapsplit.backend.feature.receipt.dto.ReceiptResponse;
 import com.google.protobuf.ByteString;
+import com.snapsplit.backend.global.exception.ReceiptProcessingException;
 import com.snapsplit.backend.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -48,8 +50,12 @@ public class ReceiptService {
         try {
             MultipartFile file = request.getFile();
 
-            // 영수증 이미지 s3 업로드
-            String receiptUrl = s3Uploader.upload(file, "receipt-images");
+            String receiptUrl;
+            try {
+                receiptUrl = s3Uploader.upload(file, "receipt-images");
+            } catch (IOException e) {
+                throw new ReceiptProcessingException("영수증 이미지 업로드에 실패했습니다.", e);
+            }
 
             String mimeType = (file.getContentType() != null) ? file.getContentType() : "image/jpeg";
 

--- a/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
+++ b/src/main/java/com/snapsplit/backend/feature/receipt/service/ReceiptService.java
@@ -9,6 +9,7 @@ import com.google.cloud.documentai.v1.RawDocument;
 import com.snapsplit.backend.feature.receipt.dto.ReceiptRequest;
 import com.snapsplit.backend.feature.receipt.dto.ReceiptResponse;
 import com.google.protobuf.ByteString;
+import com.snapsplit.backend.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ import java.util.regex.Pattern;
 public class ReceiptService {
 
     private final DocumentProcessorServiceClient client;
+    private final S3Uploader s3Uploader;
 
     @Value("${gcp.docai.project-id}")
     private String projectId;
@@ -45,6 +47,10 @@ public class ReceiptService {
     public ReceiptResponse parse(ReceiptRequest request) {
         try {
             MultipartFile file = request.getFile();
+
+            // 영수증 이미지 s3 업로드
+            String receiptUrl = s3Uploader.upload(file, "receipt-images");
+
             String mimeType = (file.getContentType() != null) ? file.getContentType() : "image/jpeg";
 
             String processor = ProcessorName.of(projectId, location, processorId).toString();
@@ -100,6 +106,7 @@ public class ReceiptService {
             return ReceiptResponse.builder()
                     .currency(currencyFinal)
                     .totalAmount(total)
+                    .receiptUrl(receiptUrl)
                     .items(items)
                     .build();
 

--- a/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snapsplit/backend/global/exception/GlobalExceptionHandler.java
@@ -42,4 +42,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.fail(500, "알 수 없는 오류가 발생했습니다."));
     }
+
+    @ExceptionHandler(ReceiptProcessingException.class)
+    public ResponseEntity<ApiResponse<Void>> handleReceiptProcessing(ReceiptProcessingException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(ApiResponse.fail(e.getStatus().value(), e.getMessage()));
+    }
 }

--- a/src/main/java/com/snapsplit/backend/global/exception/ReceiptProcessingException.java
+++ b/src/main/java/com/snapsplit/backend/global/exception/ReceiptProcessingException.java
@@ -1,0 +1,21 @@
+package com.snapsplit.backend.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ReceiptProcessingException extends RuntimeException {
+    private final HttpStatus status;
+
+    public ReceiptProcessingException(String message) {
+        super(message);
+        this.status = HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    public ReceiptProcessingException(String message, Throwable cause) {
+        super(message, cause);
+        this.status = HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/snapsplit/backend/global/s3/S3Uploader.java
+++ b/src/main/java/com/snapsplit/backend/global/s3/S3Uploader.java
@@ -1,6 +1,7 @@
 package com.snapsplit.backend.global.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import java.io.IOException;
@@ -9,6 +10,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,16 +39,29 @@ public class S3Uploader {
         return amazonS3.getUrl(bucket, fileName).toString(); // URL 반환
     }
 
-    // 객체 리스트 가져오기
+    // 객체 리스트 가져오기 (페이징 포함)
     public List<String> listObjects(String dir) {
-        ListObjectsV2Result result = amazonS3.listObjectsV2(bucket, dir);
-        return result.getObjectSummaries().stream()
-                .map(s -> String.format("https://%s.s3.%s.amazonaws.com/%s",
-                        bucket,
-                        amazonS3.getRegionName(),
-                        s.getKey()))
-                .toList();
+        List<String> urls = new ArrayList<>();
+        String continuationToken = null;
+
+        do {
+            ListObjectsV2Request request = new ListObjectsV2Request()
+                    .withBucketName(bucket)
+                    .withPrefix(dir)
+                    .withContinuationToken(continuationToken);
+
+            ListObjectsV2Result result = amazonS3.listObjectsV2(request);
+
+            result.getObjectSummaries().forEach(s ->
+                    urls.add(amazonS3.getUrl(bucket, s.getKey()).toString())
+            );
+
+            continuationToken = result.getNextContinuationToken();
+        } while (continuationToken != null);
+
+        return urls;
     }
+
 
     // 객체 삭제
     public void delete(String fileUrl) {
@@ -52,6 +70,20 @@ public class S3Uploader {
     }
 
     private String extractKeyFromUrl(String fileUrl) {
-        return fileUrl.substring(fileUrl.indexOf(".com/") + 5);
+        try {
+            URI uri = URI.create(fileUrl);
+            String path = uri.getPath(); // "/bucket/key" or "/key"
+            if (path.startsWith("/")) path = path.substring(1);
+
+            // path-style 주소인 경우 bucket/ 제거
+            if (path.startsWith(bucket + "/")) {
+                path = path.substring(bucket.length() + 1);
+            }
+
+            // 퍼센트 인코딩 해제
+            return URLDecoder.decode(path, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 S3 URL: " + fileUrl, e);
+        }
     }
 }

--- a/src/main/java/com/snapsplit/backend/global/s3/S3Uploader.java
+++ b/src/main/java/com/snapsplit/backend/global/s3/S3Uploader.java
@@ -1,12 +1,15 @@
 package com.snapsplit.backend.global.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 import java.util.UUID;
 
 
@@ -29,5 +32,26 @@ public class S3Uploader {
         amazonS3.putObject(bucket, fileName, file.getInputStream(), metadata);
 
         return amazonS3.getUrl(bucket, fileName).toString(); // URL 반환
+    }
+
+    // 객체 리스트 가져오기
+    public List<String> listObjects(String dir) {
+        ListObjectsV2Result result = amazonS3.listObjectsV2(bucket, dir);
+        return result.getObjectSummaries().stream()
+                .map(s -> String.format("https://%s.s3.%s.amazonaws.com/%s",
+                        bucket,
+                        amazonS3.getRegionName(),
+                        s.getKey()))
+                .toList();
+    }
+
+    // 객체 삭제
+    public void delete(String fileUrl) {
+        String key = extractKeyFromUrl(fileUrl);
+        amazonS3.deleteObject(bucket, key);
+    }
+
+    private String extractKeyFromUrl(String fileUrl) {
+        return fileUrl.substring(fileUrl.indexOf(".com/") + 5);
     }
 }


### PR DESCRIPTION
### ✨ 개요
영수증 업로드 → 파싱 → 지출 추가 및 상세 조회까지 연동되는 전체 흐름을 구현
업로드된 영수증은 S3에 저장되고, 지출에 연결되지 않은 파일은 Garbage Collector 배치로 주기적으로 정리

### ✅ 세부 내용
- ReceiptService: 영수증 업로드 및 DocAI 파싱 로직 구현
  - currency, items, totalAmount 추출
  - TAX 라인 처리 및 총액 계산
  - S3에 저장된 receiptUrl 응답 포함
- AddExpenseRequest: receiptUrl, items 필드 추가
- AddExpenseService: 지출 추가 시 Receipt 엔티티 저장
- ExpenseDetailResponse: receiptUrl, receiptItems 응답 추가
- ReceiptRepository: findByExpenseId 메서드 추가
- Garbage Collector 배치 추가
  - 매일 새벽 3시에 실행
  - DB에 없는 영수증 이미지 파일 S3에서 삭제
- S3Uploader: listObjects(), delete() 유틸 추가

### 🔐 관련 API
- POST /api/receipts/parse : 영수증 이미지 업로드 및 파싱
- POST /api/receipts/debug : 영수증 원본 디버그용
- POST /trips/{tripId}/expenses : 지출 추가 (영수증 연동 가능)
- GET /trips/{tripId}/expenses/{expenseId} : 지출 상세 조회 (영수증 정보 포함)

### 📝 참고 사항
- 파싱 결과는 지출 확정 전까지는 DB에 저장되지 않음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 영수증 이미지 업로드 후 자동 파싱 API 및 파싱 디버그 API 추가 (통화, 총액, 항목, 원문/엔티티 요약 제공)
  - 지출 생성 시 영수증 URL·추출 항목 저장 및 지출 상세에서 영수증 정보 노출
  - 파싱/디버그 전용 응답·요청 DTO 및 디버깅 엔드포인트 추가

- Chores
  - Google Cloud Document AI 의존성 추가 및 클라이언트 구성
  - S3 객체 목록 조회·삭제 기능 및 일일 정리 스케줄러 도입

- Bug Fixes / UX
  - 영수증 처리 오류에 대한 표준화된 오류 응답 추가
  - 입력 유효성 완화: splitters 필수 제약 해제
<!-- end of auto-generated comment: release notes by coderabbit.ai -->