### PR TITLE
[Fix] 여행 참여 API 예외 처리 로직 수정

### DIFF
--- a/src/main/java/com/snapsplit/backend/feature/joinTrip/controller/JoinTripController.java
+++ b/src/main/java/com/snapsplit/backend/feature/joinTrip/controller/JoinTripController.java
@@ -24,14 +24,7 @@ public class JoinTripController {
     @Operation(summary = "초대 코드로 여행 참여", description = "참여하고 싶은 초대 코드를 입력하여 여행에 참여합니다.")
     @PostMapping("/join")
     public ApiResponse<JoinTripResponse> joinTrip(@RequestBody JoinTripRequest request) {
-        JoinTripResult result = joinTripService.joinTrip(request.getUserId(), request.getInviteCode());
-
-        // 실패했을 시
-        if (!result.isSuccess()) {
-            return ApiResponse.fail(400, result.getMessage());
-        }
-
-        // 성공했을 시
-        return ApiResponse.success(result.getMessage(), result.getData());
+        JoinTripResponse response = joinTripService.joinTrip(request.getUserId(), request.getInviteCode());
+        return ApiResponse.success("여행에 성공적으로 참여가 완료되었습니다.", response);
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/joinTrip/service/JoinTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/joinTrip/service/JoinTripService.java
@@ -1,7 +1,6 @@
 package com.snapsplit.backend.feature.joinTrip.service;
 
-import com.snapsplit.backend.feature.joinTrip.dto.JoinTripResult;
-import org.springframework.transaction.annotation.Transactional;
+import com.snapsplit.backend.feature.joinTrip.dto.JoinTripResponse;
 import com.snapsplit.backend.domain.trip.entity.Trip;
 import com.snapsplit.backend.domain.trip.repository.TripRepository;
 import com.snapsplit.backend.domain.tripmember.entity.MemberType;
@@ -9,12 +8,9 @@ import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.domain.user.repository.UserRepository;
-import com.snapsplit.backend.feature.joinTrip.dto.JoinTripResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-
-import java.util.NoSuchElementException;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,36 +22,17 @@ public class JoinTripService {
 
     // 초대 코드로 여행 참여하기
     @Transactional
-    public JoinTripResult joinTrip(Long userId, String inviteCode) {
-        Trip trip = tripRepository.findByTripCode(inviteCode).orElse(null);
+    public JoinTripResponse joinTrip(Long userId, String inviteCode) {
+        Trip trip = tripRepository.findByTripCode(inviteCode)
+                .orElseThrow(() -> new IllegalArgumentException("초대 코드에 해당하는 여행이 없습니다."));
 
-        // 초대 코드에 해당하는 여행이 없을 시
-        if (trip == null) {
-            return JoinTripResult.builder()
-                    .success(false)
-                    .message("초대 코드에 해당하는 여행이 없습니다.")
-                    .build();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+        if (tripMemberRepository.existsByTripAndUser(trip, user)) {
+            throw new IllegalArgumentException("이미 이 여행에 참여되어 있습니다.");
         }
 
-        // 사용자 정보를 찾을 수 없을 시
-        User user = userRepository.findById(userId).orElse(null);
-        if (user == null) {
-            return JoinTripResult.builder()
-                    .success(false)
-                    .message("사용자 정보를 찾을 수 없습니다.")
-                    .build();
-        }
-
-        // 이미 여행에 참여된 사용자가 또 초대 코드로 입력했을 시
-        boolean alreadyJoined = tripMemberRepository.existsByTripAndUser(trip, user);
-        if (alreadyJoined) {
-            return JoinTripResult.builder()
-                    .success(false)
-                    .message("이미 이 여행에 참여되어 있습니다.")
-                    .build();
-        }
-
-        // 새 TripMember 생성
         TripMember tripMember = TripMember.builder()
                 .trip(trip)
                 .user(user)
@@ -63,15 +40,8 @@ public class JoinTripService {
                 .build();
         tripMemberRepository.save(tripMember);
 
-        JoinTripResponse response = JoinTripResponse.builder()
+        return JoinTripResponse.builder()
                 .tripId(trip.getId())
                 .build();
-
-        return JoinTripResult.builder()
-                .success(true)
-                .message("여행에 성공적으로 참여가 완료되었습니다.")
-                .data(response)
-                .build();
     }
-
 }

--- a/src/main/java/com/snapsplit/backend/feature/ongoingTrips/dto/OngoingTripResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/ongoingTrips/dto/OngoingTripResponse.java
@@ -16,7 +16,7 @@ public class OngoingTripResponse {
     private String startDate;
     private String endDate;
     private String tripImage;
-    private List<String> countryNames;
+    private List<String> countries;
 
     public static OngoingTripResponse from(Trip trip, List<String> countryNames) {
         return OngoingTripResponse.builder()
@@ -25,7 +25,7 @@ public class OngoingTripResponse {
                 .startDate(trip.getStartDate().toString())
                 .endDate(trip.getEndDate().toString())
                 .tripImage(trip.getTripImage())
-                .countryNames(countryNames)
+                .countries(countryNames)
                 .build();
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/dto/PastTripResponse.java
@@ -16,16 +16,16 @@ public class PastTripResponse {
     private LocalDate startDate;
     private LocalDate endDate;
     private String tripImage;
-    private List<String> countryNames;
+    private List<String> countries;
 
-    public static PastTripResponse from(Trip trip, List<String> countryNames) {
+    public static PastTripResponse from(Trip trip, List<String> countries) {
         return new PastTripResponse(
                 trip.getId(),
                 trip.getTripName(),
                 trip.getStartDate(),
                 trip.getEndDate(),
                 trip.getTripImage(),
-                countryNames
+                countries
         );
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/pastTrips/service/PastTripsService.java
+++ b/src/main/java/com/snapsplit/backend/feature/pastTrips/service/PastTripsService.java
@@ -56,7 +56,7 @@ public class PastTripsService {
 
         int totalTrips = items.size();
         int totalCountries = items.stream()
-                .flatMap(t -> t.getCountryNames().stream())
+                .flatMap(t -> t.getCountries().stream())
                 .collect(java.util.stream.Collectors.toSet())
                 .size();
 

--- a/src/main/java/com/snapsplit/backend/feature/upcomingTrips/dto/UpcomingTripResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/upcomingTrips/dto/UpcomingTripResponse.java
@@ -16,15 +16,15 @@ public class UpcomingTripResponse {
     private String tripName;
     private LocalDate startDate;
     private LocalDate endDate;
-    private List<String> countryNames;
+    private List<String> countries;
 
-    public static UpcomingTripResponse from(Trip trip, List<String> countryNames) {
+    public static UpcomingTripResponse from(Trip trip, List<String> countries) {
         return new UpcomingTripResponse(
                 trip.getId(),
                 trip.getTripName(),
                 trip.getStartDate(),
                 trip.getEndDate(),
-                countryNames
+                countries
         );
     }
 }


### PR DESCRIPTION
### ✨ 개요
초대 코드로 여행 참여(joinTrip) 로직에서 기존 joinTripResult DTO를 제거하고, 예외 상황을 Exception 기반으로 처리하도록 변경

### ✅ 세부 내용
- joinTripResultDTO 제거
- JoinTripService에서 IllegalArgumentException 예외 발생하도록 변경
- 그 외 기본 홈 DTO 네이밍 countries로 통일하도록 변경

### 🔐 관련 API
- POST `/trips/join` 초대 코드로 여행 참여
- GET `/home` 기본 홈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 여행 참여 흐름을 단일 성공 응답으로 간소화하고 고정 성공 메시지(“여행에 성공적으로 참여가 완료되었습니다.”)를 제공합니다.
  * 오류 상황은 명확한 메시지로 예외 처리되어 사용자에게 일관된 피드백을 제공합니다.
  * 여행 목록 관련 응답에서 국가 목록 필드명을 countries로 통일(기존 countryNames 대비). 진행중/예정/지난 여행 응답에 동일 적용.
  * 관련 빌더/게터 명칭도 countries 기준으로 일관화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->