### PR TITLE
[Fix] 정산하기 요청 시 startDate/endDate 관련 검증 로직 추가

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/settlement/repository/SettlementRepository.java
@@ -2,6 +2,8 @@ package com.snapsplit.backend.domain.settlement.repository;
 
 import com.snapsplit.backend.domain.settlement.entity.Settlement;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,4 +15,19 @@ public interface SettlementRepository extends JpaRepository<Settlement, Long> {
     boolean existsByTrip_IdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
             Long tripId, LocalDate startDate, LocalDate endDate
     );
+
+    //
+    @Query("""
+        select (count(s) > 0)
+        from Settlement s
+        where s.trip.id = :tripId
+          and s.startDate <= :endDate
+          and s.endDate >= :startDate
+    """)
+    boolean existsOverlapping(
+            @Param("tripId") Long tripId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementPageResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/dto/SettlementPageResponse.java
@@ -33,5 +33,6 @@ public class SettlementPageResponse {
     public static class DailyExpenseStatus {
         private LocalDate date;      // 날짜
         private boolean hasExpense;  // 해당 날짜 지출 유무
+        private boolean settled; // 해당 날짜가 정산 완료일인지 여부
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementPageService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementPageService.java
@@ -29,24 +29,39 @@ public class SettlementPageService {
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new IllegalArgumentException("여행이 존재하지 않습니다."));
 
+        // 정산 내역
+        var settlements = settlementRepository.findAllByTripId(tripId);
+
         // 정산 내역 정보
-        List<SettlementPageResponse.SettlementSummary> completeSettlement = settlementRepository.findAllByTripId(tripId).stream()
-                .map(settlement -> SettlementPageResponse.SettlementSummary.builder()
-                        .id(settlement.getId())
-                        .startDate(settlement.getStartDate())
-                        .endDate(settlement.getEndDate())
+        List<SettlementPageResponse.SettlementSummary> completeSettlement = settlements.stream()
+                .map(s -> SettlementPageResponse.SettlementSummary.builder()
+                        .id(s.getId())
+                        .startDate(s.getStartDate())
+                        .endDate(s.getEndDate())
                         .build())
                 .toList();
 
-        // 여행 기간 내 모든 지출 날짜 세트화
+        // 여행 기간 범위 설정(시작일-1 ~ 종료일)
         LocalDate start = trip.getStartDate().minusDays(1);
         LocalDate end = trip.getEndDate();
 
+        // 지출 날짜 set
         List<Expense> expensesInRange =
                 expenseRepository.findByTripIdAndExpenseDateBetween(tripId, start, end);
 
         Set<LocalDate> expenseDates = expensesInRange.stream()
                 .map(Expense::getExpenseDate)
+                .collect(Collectors.toSet());
+
+        // 정산 완료 날짜 set
+        Set<LocalDate> settledDates = settlements.stream()
+                .flatMap(s -> {
+                    List<LocalDate> days = new ArrayList<>();
+                    for (LocalDate d = s.getStartDate(); !d.isAfter(s.getEndDate()); d = d.plusDays(1)) {
+                        days.add(d);
+                    }
+                    return days.stream();
+                })
                 .collect(Collectors.toSet());
 
         // 날짜별 지출 유무 리스트 생성
@@ -56,6 +71,7 @@ public class SettlementPageService {
                     SettlementPageResponse.DailyExpenseStatus.builder()
                             .date(d)
                             .hasExpense(expenseDates.contains(d))
+                            .settled(settledDates.contains(d))
                             .build()
             );
         }

--- a/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementService.java
+++ b/src/main/java/com/snapsplit/backend/feature/settlement/service/SettlementService.java
@@ -41,9 +41,32 @@ public class SettlementService {
         LocalDate startDate = request.getStartDate();
         LocalDate endDate = request.getEndDate();
 
+        // 정산 일자 검증 로직
+        if (startDate == null || endDate == null) {
+            throw new IllegalArgumentException("정산 시작일/종료일은 필수입니다.");
+        }
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("정산 시작일은 종료일 이후가 될 수 없습니다.");
+        }
+
         // 여행 찾기
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 여행입니다."));
+
+        LocalDate minStart = trip.getStartDate().minusDays(1);
+        if (startDate.isBefore(minStart)) {
+            throw new IllegalArgumentException(
+                    "정산 시작일은 여행 시작일의 하루 전(" + minStart + ")보다 이전일 수 없습니다."
+            );
+        }
+        if (endDate.isAfter(trip.getEndDate())) {
+            throw new IllegalArgumentException("정산 종료일은 여행 종료일(" + trip.getEndDate() + ") 이후일 수 없습니다.");
+        }
+
+        boolean overlapped = settlementRepository.existsOverlapping(tripId, startDate, endDate);
+        if (overlapped) {
+            throw new IllegalArgumentException("선택한 기간에 이미 생성된 정산이 있어 중복 정산할 수 없습니다.");
+        }
 
         // 정산 대상 멤버 가져오기
         List<TripMember> tripMembers = tripMemberRepository.findAllByTripId(tripId);


### PR DESCRIPTION
### ✨ 개요
정산하기 요청 시 startDate와 endDate 관련 검증 로직을 추가

### ✅ 세부 내용
- `createSettlement` 서비스 로직에 중복 정산 검증 로직 추가
- 정산하기 시작 페이지의 `SettlementPageResponse` DTO 구조 수정

### 🔐 관련 API
- GET /trips/{tripId}/settlements
- POST /trips/{tripId}/settlements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 정산 페이지에 일자별 “정산 완료” 여부 표시가 추가되었습니다.

- 버그 수정
  - 동일 여행에서 날짜가 겹치는 정산이 생성되지 않도록 검사하여 중복 생성을 방지했습니다.
  - 시작/종료 날짜 유효성 검사를 강화해 잘못된 기간 입력 시 즉시 안내합니다.
  - 정산 데이터 조회를 최적화해 일별 상태 표시의 일관성과 응답 속도를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->