### PR TITLE
[Feat] 사진 메타 데이터 추출 및 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
     implementation platform("com.google.cloud:libraries-bom:26.49.0")
     implementation "com.google.cloud:google-cloud-document-ai"
+
+    // EXIF 메타데이터 추출
+    implementation 'com.drewnoakes:metadata-extractor:2.18.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/snapsplit/backend/feature/snap/controller/ExifDebugController.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/controller/ExifDebugController.java
@@ -1,0 +1,42 @@
+package com.snapsplit.backend.feature.snap.controller;
+
+import com.snapsplit.backend.feature.snap.service.ExifService;
+import com.snapsplit.backend.feature.snap.service.ExifService.ExifData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/debug/exif")
+public class ExifDebugController {
+
+    private final ExifService exifService;
+
+    @PostMapping(consumes = "multipart/form-data")
+    public ResponseEntity<?> read(@RequestPart("file") MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "message", "file is required"
+            ));
+        }
+
+        return exifService.extract(file)
+                .<ResponseEntity<?>>map((ExifData exif) -> ResponseEntity.ok(Map.of(
+                        "success", true,
+                        "hasExif", true,
+                        "latitude", exif.getLatitude(),
+                        "longitude", exif.getLongitude(),
+                        "takenAtLocal", exif.getTakenAtLocal() // 타임존 없는 현지 시각
+                )))
+                .orElseGet(() -> ResponseEntity.ok(Map.of(
+                        "success", true,
+                        "hasExif", false,
+                        "message", "No EXIF GPS/DateTime found"
+                )));
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/snap/dto/UploadPhotoResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/dto/UploadPhotoResponse.java
@@ -2,6 +2,8 @@ package com.snapsplit.backend.feature.snap.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -11,11 +13,26 @@ public class UploadPhotoResponse {
     private final String photoUrl;
     private final List<TaggedUser> taggedUsers;
 
+    // 사진 메타데이터
+    private final LocalDateTime takenAt;
+    private final Double latitude;
+    private final Double longitude;
+
     @Builder
-    public UploadPhotoResponse(Long photoId, String photoUrl, List<TaggedUser> taggedUsers) {
+    public UploadPhotoResponse(
+            Long photoId,
+            String photoUrl,
+            List<TaggedUser> taggedUsers,
+            LocalDateTime takenAt,
+            Double latitude,
+            Double longitude
+    ) {
         this.photoId = photoId;
         this.photoUrl = photoUrl;
         this.taggedUsers = taggedUsers;
+        this.takenAt = takenAt;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
     @Getter

--- a/src/main/java/com/snapsplit/backend/feature/snap/service/ExifService.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/service/ExifService.java
@@ -1,0 +1,61 @@
+package com.snapsplit.backend.feature.snap.service;
+
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.ExifSubIFDDirectory;
+import com.drew.metadata.exif.GpsDirectory;
+import lombok.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+public class ExifService {
+
+    /**
+     * 업로드된 파일에서 EXIF 정보 추출
+     * @param file 업로드된 사진 파일
+     * @return Optional<ExifData> (위치, 촬영시간 포함)
+     */
+    public Optional<ExifData> extract(MultipartFile file) {
+        try (InputStream in = file.getInputStream()) {
+            Metadata metadata = ImageMetadataReader.readMetadata(in);
+
+            // GPS 좌표
+            Double lat = null, lon = null;
+            GpsDirectory gps = metadata.getFirstDirectoryOfType(GpsDirectory.class);
+            if (gps != null && gps.getGeoLocation() != null) {
+                lat = gps.getGeoLocation().getLatitude();
+                lon = gps.getGeoLocation().getLongitude();
+            }
+
+            // 촬영 시간
+            Date takenAt = null;
+            ExifSubIFDDirectory exif = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
+            if (exif != null) {
+                takenAt = exif.getDateOriginal(); // DateTimeOriginal
+                if (takenAt == null) {
+                    takenAt = exif.getDateDigitized();
+                }
+            }
+
+            if (lat == null && lon == null && takenAt == null) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new ExifData(lat, lon, takenAt));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    @Value
+    public static class ExifData {
+        Double latitude;      // 위도
+        Double longitude;     // 경도
+        Date takenAtLocal;    // 촬영 시각 (타임존 정보 없음)
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
@@ -35,6 +35,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -51,6 +53,7 @@ public class SnapService {
     private final S3Uploader s3Uploader;
     private final RekognitionClient rekognitionClient;
     private final AwsProperties awsProperties;
+    private final ExifService exifService;
 
     // 여행 사진 업로드 및 자동 태깅
     @Transactional
@@ -72,10 +75,34 @@ public class SnapService {
     // 단일 이미지를 처리하는 전체 과정을 담당
     private UploadPhotoResponse processSingleImage(Album album, MultipartFile imageFile, int maxFacesToDetect) {
         try {
-            // 1. S3 업로드 및 Photo 엔티티 저장
+
+            ExifService.ExifData exif = exifService.extract(imageFile).orElse(null);
+            Double lat = null, lon = null;
+            LocalDateTime takenAt = null;
+
+            if (exif != null) {
+                lat = exif.getLatitude();
+                lon = exif.getLongitude();
+
+                if (exif.getTakenAtLocal() != null) {
+                    takenAt = LocalDateTime.ofInstant(
+                            exif.getTakenAtLocal().toInstant(),
+                            ZoneId.systemDefault()
+                    );
+                }
+            }
+
+            // 1-1. S3 업로드
             S3UploadResult uploadResult = s3Uploader.upload(imageFile, "photos");
+            // 1-2. Photo 저장 (EXIF 메타데이터 포함)
             Photo savedPhoto = photoRepository.save(
-                    Photo.builder().album(album).s3Url(uploadResult.getFileUrl()).build()
+                    Photo.builder()
+                            .album(album)
+                            .s3Url(uploadResult.getFileUrl())
+                            .photoDt(takenAt)
+                            .latitude(lat)
+                            .longitude(lon)
+                            .build()
             );
             log.info("===== [Photo: {}] 분석 시작 =====", imageFile.getOriginalFilename());
 
@@ -200,6 +227,9 @@ public class SnapService {
                 .photoId(photo.getId())
                 .photoUrl(photo.getS3Url())
                 .taggedUsers(taggedUsers)
+                .takenAt(photo.getPhotoDt())
+                .latitude(photo.getLatitude())
+                .longitude(photo.getLongitude())
                 .build();
     }
 


### PR DESCRIPTION
### ✨ 개요
사용자가 여행 사진을 업로드 시 메타 데이터(시간 및 위도, 경도)를 추출하고 저장

### ✅ 세부 내용
- `metadata-extractor` 라이브러리 활용하여 메타 데이터 추출하도록 `ExifService` 구현
- `ExifService`를 활용하여 이미지 업로드 시 EXIF 정보 추출
- 추출된 `takenAt,` `latitude`, `longitude` 값을 Photo 엔티티에 저장하도록 수정

### 🔐 관련 API
- POST /debug/exif : 메타데이터 추출 디버깅용(추후 삭제 예정)
- POST /trips/{tripId}/snap/photos : 사진 업로드 및 얼굴 자동 태깅

### 📝 참고 사항
- 위치 기반 필터링 기준 확정 후, 외부 Reverse Geocoding API(Google Maps 등) 사용 여부 결정 예정
- 현재는 시간/위도/경도만 저장, 추후 확장 가능성 있음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 사진 업로드 시 EXIF에서 촬영 일시 및 위치(위도/경도)를 자동 추출합니다.
  * 업로드 응답에 촬영 시각(takenAt), 위도, 경도 필드가 추가됩니다.

* 작업
  * EXIF 메타데이터 추출 라이브러리를 도입했습니다.
  * 개발자용 디버그 엔드포인트를 추가하여 업로드 이미지의 EXIF 존재 여부와 좌표/촬영 시각을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->