### PR TITLE
[Feat] SNAP 준비 상태 확인 및 사진 전체 조회

### DIFF
--- a/src/main/java/com/snapsplit/backend/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/photo/repository/PhotoRepository.java
@@ -1,6 +1,8 @@
 package com.snapsplit.backend.domain.photo.repository;
 
 import com.snapsplit.backend.domain.photo.entity.Photo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +11,6 @@ import java.util.Optional;
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
     List<Photo> findAllByIdInAndAlbum_Trip_Id(List<Long> ids, Long tripId);
     Optional<Photo> findByIdAndAlbum_Trip_Id(Long id, Long tripId);
+    Page<Photo> findByAlbum_Id(Long albumId, Pageable pageable);
+
 }

--- a/src/main/java/com/snapsplit/backend/domain/phototag/repository/PhotoTagRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/phototag/repository/PhotoTagRepository.java
@@ -3,6 +3,8 @@ package com.snapsplit.backend.domain.phototag.repository;
 import com.snapsplit.backend.domain.photo.entity.Photo;
 import com.snapsplit.backend.domain.phototag.entity.PhotoTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,4 +14,9 @@ public interface PhotoTagRepository extends JpaRepository<PhotoTag, Long> {
 
     // 특정 사진(photoId)에 연결된 모든 태그를 삭제
     void deleteAllByPhotoId(Long photoId);
+
+    // 특정 사진을 조회할 때 관련된 유저를 조회
+    @Query("SELECT pt FROM PhotoTag pt JOIN FETCH pt.user WHERE pt.photo.id IN :photoIds")
+    List<PhotoTag> findByPhotoIdIn(@Param("photoIds") List<Long> photoIds);
+
 }

--- a/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
@@ -68,4 +68,6 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
     @Query("SELECT tm FROM TripMember tm JOIN FETCH tm.user WHERE tm.trip.id = :tripId")
     List<TripMember> findByTripIdWithUser(@Param("tripId") Long tripId);
 
+    List<TripMember> findByUser(User user);
+
 }

--- a/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
+++ b/src/main/java/com/snapsplit/backend/domain/tripmember/repository/TripMemberRepository.java
@@ -57,4 +57,15 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
 
     int countByTrip_IdAndMemberType(Long tripId, MemberType memberType);
     List<TripMember> findAllByIdInAndTrip_Id(List<Long> ids, Long tripId);
+
+    /**
+     * 특정 여행 ID에 해당하는 모든 TripMember를 조회할 때,
+     * 관련된 User 엔티티를 함께 즉시 로딩(Eager Loading)합니다.
+     * N+1 문제를 방지하여 성능을 최적화합니다.
+     * @param tripId 조회할 여행의 ID
+     * @return User 정보가 포함된 TripMember 리스트
+     */
+    @Query("SELECT tm FROM TripMember tm JOIN FETCH tm.user WHERE tm.trip.id = :tripId")
+    List<TripMember> findByTripIdWithUser(@Param("tripId") Long tripId);
+
 }

--- a/src/main/java/com/snapsplit/backend/feature/face/service/FaceService.java
+++ b/src/main/java/com/snapsplit/backend/feature/face/service/FaceService.java
@@ -1,6 +1,8 @@
 package com.snapsplit.backend.feature.face.service;
 
 import com.snapsplit.backend.config.properties.AwsProperties;
+import com.snapsplit.backend.domain.tripmember.entity.TripMember;
+import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.domain.user.repository.UserRepository;
 import com.snapsplit.backend.global.s3.S3Uploader;
@@ -8,13 +10,17 @@ import com.snapsplit.backend.global.s3.dto.S3UploadResult;
 import com.snapsplit.backend.global.security.SecurityUtil;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.rekognition.RekognitionClient;
 import software.amazon.awssdk.services.rekognition.model.*;
 import java.io.IOException;
+import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FaceService {
@@ -24,6 +30,8 @@ public class FaceService {
     private final AwsProperties awsProperties;
     private final SecurityUtil securityUtil;
     private final S3Uploader s3Uploader;
+    private final TripMemberRepository tripMemberRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
 
     @Transactional
@@ -38,6 +46,7 @@ public class FaceService {
 
         // 2. 새로운 얼굴 정보 등록 진행
         registerNewFaceData(user, faceImage);
+        invalidateSnapReadinessCacheForUser(user); // 레디스 무효화
     }
 
     @Transactional
@@ -127,6 +136,20 @@ public class FaceService {
         long maxSize = 5 * 1024 * 1024; // 5MB
         if (fileSize > maxSize) {
             throw new IllegalArgumentException("이미지 파일 용량은 5MB를 초과할 수 없습니다.");
+        }
+    }
+
+    // Redis 무효화
+    private void invalidateSnapReadinessCacheForUser(User user) {
+        // 1. 사용자가 속한 모든 여행 멤버 정보를 조회합니다.
+        List<TripMember> userTrips = tripMemberRepository.findByUser(user);
+
+        // 2. 각 여행에 대해 캐시를 삭제합니다.
+        for (TripMember tripMember : userTrips) {
+            Long tripId = tripMember.getTrip().getId();
+            String cacheKey = "trip::" + tripId + "::snapReadiness";
+            redisTemplate.delete(cacheKey);
+            log.info("Snap 준비 상태 캐시 삭제 완료: {}", cacheKey);
         }
     }
 }

--- a/src/main/java/com/snapsplit/backend/feature/joinTrip/service/JoinTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/joinTrip/service/JoinTripService.java
@@ -9,9 +9,12 @@ import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.domain.user.entity.User;
 import com.snapsplit.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class JoinTripService {
@@ -19,6 +22,7 @@ public class JoinTripService {
     private final TripRepository tripRepository;
     private final UserRepository userRepository;
     private final TripMemberRepository tripMemberRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
     // 초대 코드로 여행 참여하기
     @Transactional
@@ -39,6 +43,11 @@ public class JoinTripService {
                 .memberType(MemberType.USER)
                 .build();
         tripMemberRepository.save(tripMember);
+
+        // 여행 멤버가 바뀌었으므로 캐시 삭제
+        String cacheKey = "trip::" + trip.getId() + "::snapReadiness";
+        redisTemplate.delete(cacheKey);
+        log.info("새 멤버 추가로 Snap 준비 상태 캐시 삭제 완료: {}", cacheKey);
 
         return JoinTripResponse.builder()
                 .tripId(trip.getId())

--- a/src/main/java/com/snapsplit/backend/feature/joinTrip/service/JoinTripService.java
+++ b/src/main/java/com/snapsplit/backend/feature/joinTrip/service/JoinTripService.java
@@ -13,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -44,11 +46,15 @@ public class JoinTripService {
                 .build();
         tripMemberRepository.save(tripMember);
 
-        // 여행 멤버가 바뀌었으므로 캐시 삭제
-        String cacheKey = "trip::" + trip.getId() + "::snapReadiness";
-        redisTemplate.delete(cacheKey);
-        log.info("새 멤버 추가로 Snap 준비 상태 캐시 삭제 완료: {}", cacheKey);
-
+        // 여행 멤버가 바뀌었으므로 커밋 이후 캐시 삭제
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                String cacheKey = "trip::" + trip.getId() + "::snapReadiness";
+                boolean deleted = redisTemplate.delete(cacheKey);
+                log.info("Snap 준비 상태 캐시 삭제 {}: {}", deleted ? "성공" : "대상 없음", cacheKey);
+            }
+        });
         return JoinTripResponse.builder()
                 .tripId(trip.getId())
                 .build();

--- a/src/main/java/com/snapsplit/backend/feature/snap/controller/SnapController.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/controller/SnapController.java
@@ -1,6 +1,7 @@
 package com.snapsplit.backend.feature.snap.controller;
 
 import com.snapsplit.backend.feature.snap.dto.DeletePhotoRequest;
+import com.snapsplit.backend.feature.snap.dto.SnapReadinessResponse;
 import com.snapsplit.backend.feature.snap.dto.UpdatePhotoTagRequest;
 import com.snapsplit.backend.feature.snap.dto.UploadPhotoResponse;
 import com.snapsplit.backend.feature.snap.service.SnapService;
@@ -23,6 +24,16 @@ import java.util.List;
 public class SnapController {
 
     private final SnapService snapService;
+
+    @CheckTripMember
+    @GetMapping("/readiness")
+    @Operation(summary = "SNAP 페이지 멤버 상태 조회", description = "모든 여행 멤버의 얼굴 등록 여부를 확인합니다.")
+    public ResponseEntity<ApiResponse<SnapReadinessResponse>> getSnapReadiness(
+            @PathVariable Long tripId
+    ) {
+        SnapReadinessResponse response = snapService.getSnapReadiness(tripId);
+        return ResponseEntity.ok(ApiResponse.success("SNAP 준비 상태 조회 성공", response));
+    }
 
     @CheckTripMember
     @PostMapping(value = "/photos", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/snapsplit/backend/feature/snap/controller/SnapController.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/controller/SnapController.java
@@ -1,15 +1,14 @@
 package com.snapsplit.backend.feature.snap.controller;
 
-import com.snapsplit.backend.feature.snap.dto.DeletePhotoRequest;
-import com.snapsplit.backend.feature.snap.dto.SnapReadinessResponse;
-import com.snapsplit.backend.feature.snap.dto.UpdatePhotoTagRequest;
-import com.snapsplit.backend.feature.snap.dto.UploadPhotoResponse;
+import com.snapsplit.backend.feature.snap.dto.*;
 import com.snapsplit.backend.feature.snap.service.SnapService;
 import com.snapsplit.backend.global.aop.CheckTripMember;
 import com.snapsplit.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +32,17 @@ public class SnapController {
     ) {
         SnapReadinessResponse response = snapService.getSnapReadiness(tripId);
         return ResponseEntity.ok(ApiResponse.success("SNAP 준비 상태 조회 성공", response));
+    }
+
+    @CheckTripMember
+    @GetMapping("/photos")
+    @Operation(summary = "Snap 사진 목록 조회", description = "여행에 업로드된 사진들을 페이지네이션으로 조회합니다.")
+    public ResponseEntity<ApiResponse<PhotoPageResponse>> getSnapPhotos(
+            @PathVariable Long tripId,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        PhotoPageResponse response = snapService.getSnapPhotos(tripId, pageable);
+        return ResponseEntity.ok(ApiResponse.success("사진 목록 조회 성공", response));
     }
 
     @CheckTripMember

--- a/src/main/java/com/snapsplit/backend/feature/snap/dto/PhotoPageResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/dto/PhotoPageResponse.java
@@ -1,0 +1,41 @@
+package com.snapsplit.backend.feature.snap.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.snapsplit.backend.domain.photo.entity.Photo;
+import com.snapsplit.backend.domain.phototag.entity.PhotoTag;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class PhotoPageResponse {
+    // 사진 정보 리스트
+    private List<PhotoDetailDto> photos;
+    // 페이징 정보
+    private int currentPage;
+    private int totalPages;
+    private long totalElements;
+    private boolean isLast;
+
+    @Getter
+    @Builder
+    public static class PhotoDetailDto {
+        private Long photoId;
+        private String photoUrl;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        private LocalDate photoDate;
+        private List<TaggedUserDto> taggedUsers;
+    }
+
+    @Getter
+    @Builder
+    public static class TaggedUserDto {
+        private Long userId;
+        private String name;
+    }
+}

--- a/src/main/java/com/snapsplit/backend/feature/snap/dto/SnapMemberStatusDto.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/dto/SnapMemberStatusDto.java
@@ -1,0 +1,16 @@
+package com.snapsplit.backend.feature.snap.dto;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonPropertyOrder({"userId", "name", "profileImageUrl", "hasFaceData", "isCurrentUser"})
+public class SnapMemberStatusDto {
+    private Long userId;
+    private String name;
+    private String profileImageUrl;
+    private boolean hasFaceData;
+    private boolean isCurrentUser;
+}

--- a/src/main/java/com/snapsplit/backend/feature/snap/dto/SnapReadinessResponse.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/dto/SnapReadinessResponse.java
@@ -1,0 +1,13 @@
+package com.snapsplit.backend.feature.snap.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SnapReadinessResponse {
+    private boolean allMembersRegistered;
+    private List<SnapMemberStatusDto> members;
+}

--- a/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
@@ -369,7 +369,10 @@ public class SnapService {
                 // [Cache Hit] 캐시가 있다면, "공용 정보" DTO로 변환
                 log.info("Cache HIT for key: {}", cacheKey);
                 cachedStatus = objectMapper.readValue(cachedDataJson, CachedSnapStatus.class);
-            } else {
+                boolean isMember = cachedStatus.getMembers().stream()
+                        .anyMatch(m->m.getUserId().equals(currentUserId));
+                if(!isMember) {throw new SecurityException("해당 여행의 멤버가 아닙니다.");
+                }} else {
                 // [Cache Miss] 캐시가 없다면, DB에서 정보를 조회하고 새로운 "공용 정보" 캐시를 생성
                 log.info("Cache MISS for key: {}", cacheKey);
 
@@ -422,8 +425,10 @@ public class SnapService {
 
         } catch (IOException e) {
             // JSON 처리 중 에러 발생 시
-            log.error("Redis 캐시 처리 중 오류 발생", e);
-            throw new RuntimeException("캐시 데이터를 처리하는 중 오류가 발생했습니다.");
+            log.warn("Redis 캐시 역직렬화 실패. 캐시 삭제 후 DB 폴백 시도. key={}", cacheKey, e);
+            redisTemplate.delete(cacheKey);
+            // 폴백: DB에서 재생성
+            return getSnapReadiness(tripId);
         }
     }
 

--- a/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
@@ -20,6 +20,8 @@ import com.snapsplit.backend.global.s3.S3Uploader;
 import com.snapsplit.backend.global.s3.dto.S3UploadResult;
 import com.snapsplit.backend.global.security.SecurityUtil;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -64,6 +66,24 @@ public class SnapService {
     private final SecurityUtil securityUtil;
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
+
+    // Redis에 저장될 공용 데이터 전체를 감싸는 DTO
+    @Getter
+    @Builder
+    private static class CachedSnapStatus {
+        private boolean allMembersRegistered;
+        private List<CachedMemberStatus> members;
+    }
+
+    // Redis에 저장될 멤버 한 명의 공용 정보 DTO
+    @Getter
+    @Builder
+    private static class CachedMemberStatus {
+        private Long userId;
+        private String name;
+        private String profileImageUrl;
+        private boolean hasFaceData;
+    }
 
     // 여행 사진 업로드 및 자동 태깅
     @Transactional
@@ -331,100 +351,77 @@ public class SnapService {
 
 
     // SNAP 페이지 준비 상태 조회 기능
-    @Transactional(readOnly = true)
     public SnapReadinessResponse getSnapReadiness(Long tripId) {
         Long currentUserId = securityUtil.getCurrentUserId();
         String cacheKey = "trip::" + tripId + "::snapReadiness";
 
-        // 1. Redis 캐시 확인
-        String cachedData = redisTemplate.opsForValue().get(cacheKey);
-
-        List<SnapMemberStatusDto> members;
-
-        if (cachedData != null) {
-            // [Cache Hit] 캐시가 있으면, 캐시 데이터 사용
-            log.info("Cache HIT for key: {}", cacheKey);
-            try {
-                // Redis에 저장된 JSON 문자열을 DTO 리스트로 변환
-                members = objectMapper.readValue(cachedData, new TypeReference<>() {});
-            } catch (IOException e) {
-                log.error("Redis cache parsing error", e);
-                // 파싱 실패 시 DB 조회로 fallback
-                return buildResponseFromDB(tripId, currentUserId);
-            }
-        } else {
-            // [Cache Miss] 캐시가 없으면, DB에서 조회하고 Redis에 저장
-            log.info("Cache MISS for key: {}", cacheKey);
-            return buildResponseFromDB(tripId, currentUserId);
-        }
-
-        // 2. isCurrentUser 동적 추가 및 allMembersRegistered 계산
-        final List<SnapMemberStatusDto> finalMembers = members.stream()
-                .map(member -> SnapMemberStatusDto.builder()
-                        .userId(member.getUserId())
-                        .name(member.getName())
-                        .profileImageUrl(member.getProfileImageUrl())
-                        .hasFaceData(member.isHasFaceData())
-                        .isCurrentUser(member.getUserId().equals(currentUserId))
-                        .build())
-                .collect(Collectors.toList());
-
-        boolean allMembersRegistered = finalMembers.stream().allMatch(SnapMemberStatusDto::isHasFaceData);
-
-        return SnapReadinessResponse.builder()
-                .allMembersRegistered(allMembersRegistered)
-                .members(finalMembers)
-                .build();
-    }
-
-    private SnapReadinessResponse buildResponseFromDB(Long tripId, Long currentUserId) {
-        // 1. DB에서 여행 멤버 조회 및 인가 확인
-        List<TripMember> tripMembers = tripMemberRepository.findByTripIdWithUser(tripId);
-        if (tripMembers.isEmpty()) {
-            throw new EntityNotFoundException("해당 여행을 찾을 수 없거나 멤버가 없습니다.");
-        }
-        tripMembers.stream()
-                .filter(tm -> tm.getUser().getId().equals(currentUserId))
-                .findFirst()
-                .orElseThrow(() -> new SecurityException("해당 여행의 멤버가 아닙니다."));
-
-        // 2. DTO 리스트 생성 (isCurrentUser 제외)
-        List<SnapMemberStatusDto> membersToCache = tripMembers.stream()
-                .map(tm -> SnapMemberStatusDto.builder()
-                        .userId(tm.getUser().getId())
-                        .name(tm.getUser().getName())
-                        .profileImageUrl(tm.getUser().getProfileImage())
-                        .hasFaceData(tm.getUser().getFaceImageUrl() != null)
-                        .isCurrentUser(false) // 캐시에는 isCurrentUser를 false로 저장
-                        .build())
-                .collect(Collectors.toList());
-
-        // 3. Redis에 캐시 저장 (유효기간: 1일)
         try {
-            String cacheValue = objectMapper.writeValueAsString(membersToCache);
-            String cacheKey = "trip::" + tripId + "::snapReadiness";
-            redisTemplate.opsForValue().set(cacheKey, cacheValue, 1, TimeUnit.DAYS);
+            // 1. Redis에서 캐시된 "공용 정보"를 먼저 조회
+            String cachedDataJson = redisTemplate.opsForValue().get(cacheKey);
+            CachedSnapStatus cachedStatus;
+
+            if (cachedDataJson != null) {
+                // [Cache Hit] 캐시가 있다면, "공용 정보" DTO로 변환
+                log.info("Cache HIT for key: {}", cacheKey);
+                cachedStatus = objectMapper.readValue(cachedDataJson, CachedSnapStatus.class);
+            } else {
+                // [Cache Miss] 캐시가 없다면, DB에서 정보를 조회하고 새로운 "공용 정보" 캐시를 생성
+                log.info("Cache MISS for key: {}", cacheKey);
+
+                List<TripMember> membersFromDb = tripMemberRepository.findByTripIdWithUser(tripId);
+                if (membersFromDb.isEmpty()) {
+                    throw new EntityNotFoundException("해당 여행을 찾을 수 없거나 멤버가 없습니다.");
+                }
+                // 인가 확인: 요청한 사용자가 이 여행의 멤버인지 확인
+                membersFromDb.stream()
+                        .filter(tm -> tm.getUser().getId().equals(currentUserId))
+                        .findFirst()
+                        .orElseThrow(() -> new SecurityException("해당 여행의 멤버가 아닙니다."));
+
+                // DB 결과를 "공용 정보" DTO 리스트로 변환합니다.
+                List<CachedMemberStatus> memberStatusList = membersFromDb.stream()
+                        .map(tm -> CachedMemberStatus.builder()
+                                .userId(tm.getUser().getId())
+                                .name(tm.getUser().getName())
+                                .profileImageUrl(tm.getUser().getProfileImage())
+                                .hasFaceData(tm.getUser().getFaceImageUrl() != null)
+                                .build())
+                        .collect(Collectors.toList());
+
+                boolean allRegistered = memberStatusList.stream().allMatch(CachedMemberStatus::isHasFaceData);
+
+                cachedStatus = CachedSnapStatus.builder()
+                        .allMembersRegistered(allRegistered)
+                        .members(memberStatusList)
+                        .build();
+
+                // 생성된 "공용 정보"를 JSON으로 변환하여 Redis에 저장
+                redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(cachedStatus));
+            }
+
+            // 2. 최종적으로, "공용 정보"에 "개인 정보(isCurrentUser)"를 동적으로 추가하여 프론트엔드에 응답
+            List<SnapMemberStatusDto> finalMemberList = cachedStatus.getMembers().stream()
+                    .map(cm -> SnapMemberStatusDto.builder()
+                            .userId(cm.getUserId())
+                            .name(cm.getName())
+                            .profileImageUrl(cm.getProfileImageUrl())
+                            .hasFaceData(cm.isHasFaceData())
+                            .isCurrentUser(cm.getUserId().equals(currentUserId)) // ★★★ 이 부분에서 동적으로 계산!
+                            .build())
+                    .collect(Collectors.toList());
+
+            return SnapReadinessResponse.builder()
+                    .allMembersRegistered(cachedStatus.isAllMembersRegistered())
+                    .members(finalMemberList)
+                    .build();
+
         } catch (IOException e) {
-            log.error("Redis cache serialization error", e);
+            // JSON 처리 중 에러 발생 시
+            log.error("Redis 캐시 처리 중 오류 발생", e);
+            throw new RuntimeException("캐시 데이터를 처리하는 중 오류가 발생했습니다.");
         }
-
-        // 4. isCurrentUser 동적 추가 및 최종 응답 생성
-        List<SnapMemberStatusDto> finalMembers = membersToCache.stream()
-                .map(member -> SnapMemberStatusDto.builder()
-                        .userId(member.getUserId())
-                        .name(member.getName())
-                        .profileImageUrl(member.getProfileImageUrl())
-                        .hasFaceData(member.isHasFaceData())
-                        .isCurrentUser(member.getUserId().equals(currentUserId))
-                        .build())
-                .collect(Collectors.toList());
-
-        boolean allMembersRegistered = finalMembers.stream().allMatch(SnapMemberStatusDto::isHasFaceData);
-
-        return SnapReadinessResponse.builder()
-                .allMembersRegistered(allMembersRegistered)
-                .members(finalMembers)
-                .build();
     }
+
+
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
@@ -1,6 +1,7 @@
 package com.snapsplit.backend.feature.snap.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import com.snapsplit.backend.config.properties.AwsProperties;
 import com.snapsplit.backend.domain.album.entity.Album;
 import com.snapsplit.backend.domain.album.repository.AlbumRepository;
@@ -12,10 +13,7 @@ import com.snapsplit.backend.domain.tripmember.entity.MemberType;
 import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.domain.user.repository.UserRepository;
-import com.snapsplit.backend.feature.snap.dto.SnapMemberStatusDto;
-import com.snapsplit.backend.feature.snap.dto.SnapReadinessResponse;
-import com.snapsplit.backend.feature.snap.dto.UpdatePhotoTagRequest;
-import com.snapsplit.backend.feature.snap.dto.UploadPhotoResponse;
+import com.snapsplit.backend.feature.snap.dto.*;
 import com.snapsplit.backend.global.s3.S3Uploader;
 import com.snapsplit.backend.global.s3.dto.S3UploadResult;
 import com.snapsplit.backend.global.security.SecurityUtil;
@@ -24,6 +22,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +33,8 @@ import software.amazon.awssdk.services.rekognition.RekognitionClient;
 import software.amazon.awssdk.services.rekognition.model.*;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -48,6 +50,7 @@ import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -66,6 +69,8 @@ public class SnapService {
     private final SecurityUtil securityUtil;
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
+    @Value("${snap.readiness-check-enabled}")
+    private boolean readinessCheckEnabled;
 
     // Redis에 저장될 공용 데이터 전체를 감싸는 DTO
     @Getter
@@ -422,6 +427,88 @@ public class SnapService {
         }
     }
 
+
+    // 특정 여행의 사진 목록을 페이지네이션으로 조회
+    @Transactional(readOnly = true)
+    public PhotoPageResponse getSnapPhotos(Long tripId, Pageable pageable) {
+
+        // 1. AOP로 분리할 보안 검사 로직 (개발 중에는 yml 스위치로 제어)
+        verifySnapReadiness(tripId);
+
+        // 2. 정렬 로직
+        Sort originalSort = pageable.getSort();
+        Sort finalSort;
+
+        if (originalSort.isSorted()) {
+            Stream<Sort.Order> translatedOrders = originalSort.stream()
+                    .map(order -> {
+                        // 만약 정렬 기준이 'photoDate'라면,
+                        if (order.getProperty().equals("photoDate")) {
+                            // 실제 엔티티 필드명인 'photoDt'로 바꿔줍니다. (정렬 방향은 그대로 유지)
+                            return new Sort.Order(order.getDirection(), "photoDt");
+                        }
+                        // 다른 정렬 기준은 그대로 둡니다.
+                        return order;
+                    });
+            finalSort = Sort.by(translatedOrders.toList());
+        } else {
+            // 4. 정렬 요청이 없다면, 우리의 기본 정렬 규칙을 '내부용 이름'으로 적용합니다.
+            finalSort = Sort.by(
+                    Sort.Order.desc("photoDt").with(Sort.NullHandling.NULLS_LAST),
+                    Sort.Order.desc("id")
+            );
+        }
+        Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), finalSort);
+
+        // 3. 앨범 조회 및 사진 목록 조회
+        Album album = albumRepository.findByTripId(tripId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 여행의 앨범을 찾을 수 없습니다."));
+
+        Page<Photo> photoPage = photoRepository.findByAlbum_Id(album.getId(), sortedPageable);
+        List<Photo> photos = photoPage.getContent();
+
+        // 4. N+1 문제 해결을 위한 태그 정보 조회
+        List<Long> photoIds = photos.stream().map(Photo::getId).collect(Collectors.toList());
+        List<PhotoTag> tags = photoTagRepository.findByPhotoIdIn(photoIds);
+        Map<Long, List<PhotoPageResponse.TaggedUserDto>> tagsByPhotoId = tags.stream()
+                .collect(Collectors.groupingBy(
+                        tag -> tag.getPhoto().getId(),
+                        Collectors.mapping(tag -> PhotoPageResponse.TaggedUserDto.builder()
+                                .userId(tag.getUser().getId())
+                                .name(tag.getUser().getName())
+                                .build(), Collectors.toList())
+                ));
+
+        // 5. 최종 응답 DTO 조립
+        List<PhotoPageResponse.PhotoDetailDto> photoDetailDtos = photos.stream()
+                .map(photo -> PhotoPageResponse.PhotoDetailDto.builder()
+                        .photoId(photo.getId())
+                        .photoUrl(photo.getS3Url())
+                        .photoDate(photo.getPhotoDt() != null ? photo.getPhotoDt().toLocalDate() : null)
+                        .taggedUsers(tagsByPhotoId.getOrDefault(photo.getId(), Collections.emptyList()))
+                        .build())
+                .collect(Collectors.toList());
+
+        // 6. 페이지 정보와 함께 최종 응답 반환
+        return PhotoPageResponse.builder()
+                .photos(photoDetailDtos)
+                .currentPage(photoPage.getNumber())
+                .totalPages(photoPage.getTotalPages())
+                .totalElements(photoPage.getTotalElements())
+                .isLast(photoPage.isLast())
+                .build();
+    }
+
+    private void verifySnapReadiness(Long tripId) {
+        if (readinessCheckEnabled) {
+            List<TripMember> members = tripMemberRepository.findByTripIdWithUser(tripId);
+            boolean allRegistered = members.stream()
+                    .allMatch(member -> member.getUser().getFaceImageUrl() != null);
+            if (!allRegistered) {
+                throw new IllegalStateException("모든 여행 멤버의 얼굴이 등록되지 않아 Snap 기능을 사용할 수 없습니다.");
+            }
+        }
+    }
 
 
 }

--- a/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
+++ b/src/main/java/com/snapsplit/backend/feature/snap/service/SnapService.java
@@ -1,5 +1,6 @@
 package com.snapsplit.backend.feature.snap.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snapsplit.backend.config.properties.AwsProperties;
 import com.snapsplit.backend.domain.album.entity.Album;
 import com.snapsplit.backend.domain.album.repository.AlbumRepository;
@@ -11,13 +12,17 @@ import com.snapsplit.backend.domain.tripmember.entity.MemberType;
 import com.snapsplit.backend.domain.tripmember.entity.TripMember;
 import com.snapsplit.backend.domain.tripmember.repository.TripMemberRepository;
 import com.snapsplit.backend.domain.user.repository.UserRepository;
+import com.snapsplit.backend.feature.snap.dto.SnapMemberStatusDto;
+import com.snapsplit.backend.feature.snap.dto.SnapReadinessResponse;
 import com.snapsplit.backend.feature.snap.dto.UpdatePhotoTagRequest;
 import com.snapsplit.backend.feature.snap.dto.UploadPhotoResponse;
 import com.snapsplit.backend.global.s3.S3Uploader;
 import com.snapsplit.backend.global.s3.dto.S3UploadResult;
+import com.snapsplit.backend.global.security.SecurityUtil;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,6 +30,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.rekognition.RekognitionClient;
 import software.amazon.awssdk.services.rekognition.model.*;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -38,6 +44,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -54,6 +61,9 @@ public class SnapService {
     private final RekognitionClient rekognitionClient;
     private final AwsProperties awsProperties;
     private final ExifService exifService;
+    private final SecurityUtil securityUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     // 여행 사진 업로드 및 자동 태깅
     @Transactional
@@ -317,6 +327,104 @@ public class SnapService {
                 .collect(Collectors.toList());
 
         return createUploadResponse(photo, taggedUsers);
+    }
+
+
+    // SNAP 페이지 준비 상태 조회 기능
+    @Transactional(readOnly = true)
+    public SnapReadinessResponse getSnapReadiness(Long tripId) {
+        Long currentUserId = securityUtil.getCurrentUserId();
+        String cacheKey = "trip::" + tripId + "::snapReadiness";
+
+        // 1. Redis 캐시 확인
+        String cachedData = redisTemplate.opsForValue().get(cacheKey);
+
+        List<SnapMemberStatusDto> members;
+
+        if (cachedData != null) {
+            // [Cache Hit] 캐시가 있으면, 캐시 데이터 사용
+            log.info("Cache HIT for key: {}", cacheKey);
+            try {
+                // Redis에 저장된 JSON 문자열을 DTO 리스트로 변환
+                members = objectMapper.readValue(cachedData, new TypeReference<>() {});
+            } catch (IOException e) {
+                log.error("Redis cache parsing error", e);
+                // 파싱 실패 시 DB 조회로 fallback
+                return buildResponseFromDB(tripId, currentUserId);
+            }
+        } else {
+            // [Cache Miss] 캐시가 없으면, DB에서 조회하고 Redis에 저장
+            log.info("Cache MISS for key: {}", cacheKey);
+            return buildResponseFromDB(tripId, currentUserId);
+        }
+
+        // 2. isCurrentUser 동적 추가 및 allMembersRegistered 계산
+        final List<SnapMemberStatusDto> finalMembers = members.stream()
+                .map(member -> SnapMemberStatusDto.builder()
+                        .userId(member.getUserId())
+                        .name(member.getName())
+                        .profileImageUrl(member.getProfileImageUrl())
+                        .hasFaceData(member.isHasFaceData())
+                        .isCurrentUser(member.getUserId().equals(currentUserId))
+                        .build())
+                .collect(Collectors.toList());
+
+        boolean allMembersRegistered = finalMembers.stream().allMatch(SnapMemberStatusDto::isHasFaceData);
+
+        return SnapReadinessResponse.builder()
+                .allMembersRegistered(allMembersRegistered)
+                .members(finalMembers)
+                .build();
+    }
+
+    private SnapReadinessResponse buildResponseFromDB(Long tripId, Long currentUserId) {
+        // 1. DB에서 여행 멤버 조회 및 인가 확인
+        List<TripMember> tripMembers = tripMemberRepository.findByTripIdWithUser(tripId);
+        if (tripMembers.isEmpty()) {
+            throw new EntityNotFoundException("해당 여행을 찾을 수 없거나 멤버가 없습니다.");
+        }
+        tripMembers.stream()
+                .filter(tm -> tm.getUser().getId().equals(currentUserId))
+                .findFirst()
+                .orElseThrow(() -> new SecurityException("해당 여행의 멤버가 아닙니다."));
+
+        // 2. DTO 리스트 생성 (isCurrentUser 제외)
+        List<SnapMemberStatusDto> membersToCache = tripMembers.stream()
+                .map(tm -> SnapMemberStatusDto.builder()
+                        .userId(tm.getUser().getId())
+                        .name(tm.getUser().getName())
+                        .profileImageUrl(tm.getUser().getProfileImage())
+                        .hasFaceData(tm.getUser().getFaceImageUrl() != null)
+                        .isCurrentUser(false) // 캐시에는 isCurrentUser를 false로 저장
+                        .build())
+                .collect(Collectors.toList());
+
+        // 3. Redis에 캐시 저장 (유효기간: 1일)
+        try {
+            String cacheValue = objectMapper.writeValueAsString(membersToCache);
+            String cacheKey = "trip::" + tripId + "::snapReadiness";
+            redisTemplate.opsForValue().set(cacheKey, cacheValue, 1, TimeUnit.DAYS);
+        } catch (IOException e) {
+            log.error("Redis cache serialization error", e);
+        }
+
+        // 4. isCurrentUser 동적 추가 및 최종 응답 생성
+        List<SnapMemberStatusDto> finalMembers = membersToCache.stream()
+                .map(member -> SnapMemberStatusDto.builder()
+                        .userId(member.getUserId())
+                        .name(member.getName())
+                        .profileImageUrl(member.getProfileImageUrl())
+                        .hasFaceData(member.isHasFaceData())
+                        .isCurrentUser(member.getUserId().equals(currentUserId))
+                        .build())
+                .collect(Collectors.toList());
+
+        boolean allMembersRegistered = finalMembers.stream().allMatch(SnapMemberStatusDto::isHasFaceData);
+
+        return SnapReadinessResponse.builder()
+                .allMembersRegistered(allMembersRegistered)
+                .members(finalMembers)
+                .build();
     }
 
 }


### PR DESCRIPTION
### ✨ 개요
- 모든 여행 멤버의 얼굴 등록이 완료된 후 SNAP기능 사용을 가능하게 하는 초기화면 구현
- 얼굴 등록이 완료되었을 시 불러와지는 SNAP의 전체 사진 목록 조회 구현

### ✅ 세부 내용
- SNAP페이지 접근시 /readiness로 접근 후
  - "allMembersRegistered": true일 때만 프론트에서 /photos 조회 API 호출하기
- Redis 캐시 이용하여 특정 인물이 얼굴을 최초 등록하거나, 새로운 여행 멤버가 추가되었을 시에만 캐시 무효화함
- 사진 전체 조회
  - 디폴트 정렬 기준은 찍은 날짜 내림차순(최신순)
  - 페이지네이션 사이즈 20 적용
  - 포함되는 사진 정보 : photoId, photoUrl, photoDate, taggedUsers(userId, name) 

### 🔐 관련 API
- GET /trips/{tripId}/snap/readiness
- GET /trips/{tripId}/snap/photos

### 📝 참고 사항
- Swagger 문서 (/swagger-ui/index.html) 자동 반영됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 스냅 준비 상태 조회 API 추가: 멤버별 등록 상태 및 전체 준비 여부 제공.
  * 스냅 사진 목록 조회 API 추가: 페이지네이션(기본 20개) 및 태그된 사용자 정보 포함.
  * 사진 목록 페이징 지원 및 상세 페이징 응답 추가.

* **Bug Fixes / Improvements**
  * 얼굴 등록 및 여행 참여 시 스냅 준비 상태 캐시 즉시 무효화로 최신 상태 반영.
  * 태그·멤버 연관 데이터 사전로딩으로 목록 응답 성능 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->